### PR TITLE
[FEATURE] Dark/light theme system and accent color customization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,60 @@
 
 This document describes the background threads, async backup/restore operations, and error handling used in GoldenNugget.
 
+## Color Theme System (src/gui/theme/)
+
+Dark/light mode + accent color customization for the whole GUI.
+
+- `colors.py` — frozen dataclass `ThemeColors` with `DARK` and `LIGHT` palettes
+  (named slots: `bg_primary`, `bg_secondary`, `bg_input`, `text_primary`,
+  `text_secondary`, `accent`, `divider`, `error`, `success`, ...). `ACCENT_PRESETS`
+  holds 8 accent hex colors (blue/purple/pink/red/orange/yellow/green/teal).
+- `theme_manager.py` — `ColorThemeManager` singleton (`instance()`): `mode`
+  (`"dark"`/`"light"`), `accent_hex()`, `is_dark`, `set_mode()`, `set_accent()`,
+  `set_system_theme(mode)`, `apply_system_theme(dark)` (follows the OS but never
+  overrides a user choice — `_has_explicit_mode` becomes set the moment the
+  Settings switch saves a mode), `c(slot)` (color accessor), `build_palette()`
+  (QPalette for native widgets). Persisted via QSettings (`color_mode`,
+  `accent_color`). Emits `theme_changed` (no payload) on any color change.
+- `styles.py` — `STYLES` dict of Qt stylesheet templates using `{slot}` named
+  placeholders (literal braces are doubled `{{`/`}}`).
+- `accent_picker.py` — `AccentPicker` widget: row of circular preset buttons,
+  self-connects to `theme_changed` to repaint its selection border.
+- `__init__.py` — exports the above plus `t(style_key) -> str`.
+
+### Styling contract (IMPORTANT)
+
+- `t(key)` is the **only** way widgets read theme colors; it renders the
+  template with the current palette **internally** (`format_map`). Callers must
+  use `widget.setStyleSheet(t("key"))` and **must NOT** call `.format_map()`
+  again on top of `t(...)` (double-formatting breaks on the `{{` escapes).
+- Any widget/page that draws theme colors implements `_retheme(self)` which
+  re-applies all its stylesheets from `ColorThemeManager.instance().colors`.
+  It is called by `MainWindow._on_color_theme_changed` for every `ios_pages`
+  entry (line 224 of `src/gui/main_window.py`) AND by self-connections.
+- Reused components in `src/gui/ios/components.py` call
+  `_auto_retheme(self)` from their `__init__` (defined at module level),
+  which connects `ColorThemeManager.instance().theme_changed` to their
+  `_retheme` — authoritative, one connection per instance. Child widgets
+  created before `_auto_retheme(self)` must be registered by hand or use
+  the shared `IOSNavBar`/`IOSSwitch`/etc. components which self-connect.
+- The whole-window stylesheet is `t("global")`, applied in
+  `MainWindow._apply_global_stylesheet`; it sets `QLabel color` via the
+  `QWidget { color: {text_primary} }` rule, so bare labels inside styled
+  rows pick up the theme without their own `_retheme`.
+- `src/qt/mainwindow_ui.py` is generated from Qt Designer — do not edit;
+  theme the chrome via `_apply_global_stylesheet` instead.
+- Old `src/gui/ios/theme_manager.py` (`CLASSIC`/`IOS`) is layout-only
+  (Classic vs iOS-style chrome) and stays untouched side-by-side.
+- Theme UI lives in Settings → **Appearance** (`src/gui/ios/settings.py`):
+  "Dark Mode" `IOSSwitch` (`set_mode`) and "Accent Color" `AccentPicker`
+  (`set_accent`). The switch's initial `setChecked` uses `is_dark`.
+- System-theme detection is wired in `main_app.py` right after the QApplication
+  is created: `QStyleHints.colorSchemeChanged` drives
+  `apply_system_theme(...)`. The app follows the OS until the user toggles the
+  Dark Mode switch, then the persisted `color_mode` wins and OS changes are
+  ignored.
+
 ## HotLoad Safety Rules (src/controllers/hotload.py)
 
 Remote safety rules (cached from

--- a/main_app.py
+++ b/main_app.py
@@ -126,31 +126,26 @@ def main() -> int:
 
     app = CrashHandlerApp([])
 
-    # Force a dark theme matching the Nugget style on every platform, so the
-    # app always renders dark regardless of the OS appearance. The Fusion style
-    # is required for a custom QPalette to take effect on all platforms (native
-    # styles ignore palette tweaks), and the palette covers native widgets,
-    # menus, tooltips, dialogs and any widget without an explicit stylesheet.
+    # Fusion style is required for a custom QPalette to take effect on all
+    # platforms (native styles ignore palette tweaks).  The palette is now
+    # managed by ColorThemeManager so it can switch between dark/light.
     app.setStyle("Fusion")
-    from PySide6.QtGui import QColor, QPalette
-    dark_palette = QPalette()
-    dark_palette.setColor(QPalette.ColorRole.Window, QColor(30, 30, 32))
-    dark_palette.setColor(QPalette.ColorRole.WindowText, QColor(220, 220, 220))
-    dark_palette.setColor(QPalette.ColorRole.Base, QColor(25, 25, 27))
-    dark_palette.setColor(QPalette.ColorRole.AlternateBase, QColor(35, 35, 38))
-    dark_palette.setColor(QPalette.ColorRole.ToolTipBase, QColor(30, 30, 32))
-    dark_palette.setColor(QPalette.ColorRole.ToolTipText, QColor(220, 220, 220))
-    dark_palette.setColor(QPalette.ColorRole.Text, QColor(220, 220, 220))
-    dark_palette.setColor(QPalette.ColorRole.Button, QColor(45, 45, 48))
-    dark_palette.setColor(QPalette.ColorRole.ButtonText, QColor(220, 220, 220))
-    dark_palette.setColor(QPalette.ColorRole.BrightText, QColor(255, 100, 100))
-    dark_palette.setColor(QPalette.ColorRole.Link, QColor(0, 122, 255))
-    dark_palette.setColor(QPalette.ColorRole.Highlight, QColor(0, 122, 255))
-    dark_palette.setColor(QPalette.ColorRole.HighlightedText, QColor(255, 255, 255))
-    dark_palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text, QColor(120, 120, 120))
-    dark_palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.ButtonText, QColor(120, 120, 120))
-    dark_palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.WindowText, QColor(120, 120, 120))
-    app.setPalette(dark_palette)
+
+    from src.gui.theme import ColorThemeManager
+    _color_theme = ColorThemeManager.instance()
+    app.setPalette(_color_theme.build_palette())
+
+    # Follow the OS dark/light mode until the user picks one manually in
+    # Settings -> Appearance (that choice persists and takes precedence).
+    from PySide6.QtCore import Qt
+    _style_hints = app.styleHints()
+    try:
+        _current_scheme = _style_hints.colorScheme()
+        _color_theme.apply_system_theme(_current_scheme == Qt.ColorScheme.Dark)
+        _style_hints.colorSchemeChanged.connect(
+            lambda scheme: _color_theme.apply_system_theme(scheme == Qt.ColorScheme.Dark))
+    except Exception:
+        pass
 
     dm = DeviceManager()
 

--- a/src/gui/dialogs/dialogs.py
+++ b/src/gui/dialogs/dialogs.py
@@ -51,6 +51,7 @@ from src.controllers.web_request_handler import Nugget_Repo, get_latest_version
 
 # App version
 from src.gui.version import App_Version, App_Build
+from src.gui.theme import ColorThemeManager
 
 
 class AboutProgramDialog(QDialog):
@@ -59,19 +60,7 @@ class AboutProgramDialog(QDialog):
         self.setWindowTitle(self.tr("About GoldenNugget"))
         self.setMinimumSize(500, 600)
         self.setModal(True)
-        self.setStyleSheet("""
-            QDialog { background-color: #1e1e1e; }
-            QDialogButtonBox QPushButton {
-                background-color: #007AFF;
-                border-radius: 10px;
-                color: #FFFFFF;
-                font-size: 15px;
-                font-weight: 600;
-                padding: 10px 24px;
-                border: none;
-            }
-            QDialogButtonBox QPushButton:hover { background-color: #0066CC; }
-        """)
+        self._retheme()
         QBtn = QDialogButtonBox.Ok
         self.buttonBox = QDialogButtonBox(QBtn)
         self.buttonBox.accepted.connect(self.accept)
@@ -103,9 +92,10 @@ class AboutProgramDialog(QDialog):
         version_str = f"v{App_Version}"
         if App_Build > 0:
             version_str += f" (beta {App_Build})"
+        c = ColorThemeManager.instance().colors
         version_label = QLabel(version_str)
         version_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        version_label.setStyleSheet("color: #8E8E93; font-size: 15px;")
+        version_label.setStyleSheet(f"color: {c.text_secondary}; font-size: 15px;")
         name_layout.addWidget(version_label)
         
         header_layout.addLayout(name_layout)
@@ -114,19 +104,19 @@ class AboutProgramDialog(QDialog):
         # Separator
         separator = QFrame()
         separator.setFrameShape(QFrame.Shape.HLine)
-        separator.setStyleSheet("color: #3A3A3C;")
+        separator.setStyleSheet(f"color: {c.border};")
         layout.addWidget(separator)
         
         # Description
         desc = QLabel(self.tr("Customize your iOS device with animated wallpapers, system tweaks, and more. Built for iOS 26.2+."))
         desc.setWordWrap(True)
         desc.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        desc.setStyleSheet("color: #EBEBF599; font-size: 15px; padding: 0 20px;")
+        desc.setStyleSheet(f"color: {c.text_secondary}; font-size: 15px; padding: 0 20px;")
         layout.addWidget(desc)
         
         # Credits section
         credits_title = QLabel(self.tr("Credits"))
-        credits_title.setStyleSheet("font-size: 17px; font-weight: 600; color: #FFFFFF; padding-top: 8px;")
+        credits_title.setStyleSheet(f"font-size: 17px; font-weight: 600; color: {c.text_primary}; padding-top: 8px;")
         layout.addWidget(credits_title)
         
         # Scrollable credits
@@ -134,11 +124,11 @@ class AboutProgramDialog(QDialog):
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QFrame.Shape.NoFrame)
         scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        scroll.setStyleSheet("""
-            QScrollArea { background: transparent; border: none; }
-            QWidget { background: transparent; }
-            QScrollBar:vertical { width: 6px; background: transparent; }
-            QScrollBar::handle { background: #3A3A3C; border-radius: 3px; min-height: 30px; }
+        scroll.setStyleSheet(f"""
+            QScrollArea {{ background: transparent; border: none; }}
+            QWidget {{ background: transparent; }}
+            QScrollBar:vertical {{ width: 6px; background: transparent; }}
+            QScrollBar::handle {{ background: {c.border}; border-radius: 3px; min-height: 30px; }}
         """)
         
         credits_widget = QWidget()
@@ -170,23 +160,23 @@ class AboutProgramDialog(QDialog):
             item_layout.setContentsMargins(0, 0, 0, 0)
             
             title_label = QLabel(f"{title}:")
-            title_label.setStyleSheet("color: #EBEBF599; font-size: 14px; font-weight: 500; min-width: 160px;")
+            title_label.setStyleSheet(f"color: {c.text_secondary}; font-size: 14px; font-weight: 500; min-width: 160px;")
             item_layout.addWidget(title_label)
             
             name_btn = QToolButton()
             name_btn.setText(name)
             name_btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
             name_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-            name_btn.setStyleSheet("""
-                QToolButton { 
-                    color: #007AFF; 
+            name_btn.setStyleSheet(f"""
+                QToolButton {{ 
+                    color: {c.accent}; 
                     font-size: 14px; 
                     background: none; 
                     border: none; 
                     padding: 0; 
                     text-align: left;
-                }
-                QToolButton:hover { color: #0066CC; text-decoration: underline; }
+                }}
+                QToolButton:hover {{ color: {c.accent_hover}; text-decoration: underline; }}
             """)
             name_btn.clicked.connect(lambda _, u=url: QDesktopServices.openUrl(QUrl(u)))
             item_layout.addWidget(name_btn)
@@ -206,7 +196,7 @@ class AboutProgramDialog(QDialog):
         github_btn.setText("GitHub")
         github_btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
         github_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-        github_btn.setStyleSheet("QToolButton { color: #007AFF; font-size: 14px; font-weight: 500; background: none; border: none; padding: 4px 8px; } QToolButton:hover { text-decoration: underline; }")
+        github_btn.setStyleSheet(f"QToolButton {{ color: {c.accent}; font-size: 14px; font-weight: 500; background: none; border: none; padding: 4px 8px; }} QToolButton:hover {{ text-decoration: underline; }}")
         github_btn.clicked.connect(lambda: QDesktopServices.openUrl(QUrl("https://github.com/awesomenull-dev/GoldenNugget")))
         links_layout.addWidget(github_btn)
         
@@ -214,7 +204,7 @@ class AboutProgramDialog(QDialog):
         website_btn.setText("Wallpapers")
         website_btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
         website_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-        website_btn.setStyleSheet("QToolButton { color: #007AFF; font-size: 14px; font-weight: 500; background: none; border: none; padding: 4px 8px; } QToolButton:hover { text-decoration: underline; }")
+        website_btn.setStyleSheet(f"QToolButton {{ color: {c.accent}; font-size: 14px; font-weight: 500; background: none; border: none; padding: 4px 8px; }} QToolButton:hover {{ text-decoration: underline; }}")
         website_btn.clicked.connect(lambda: QDesktopServices.openUrl(QUrl("https://cowabun.ga/wallpapers")))
         links_layout.addWidget(website_btn)
         
@@ -222,13 +212,29 @@ class AboutProgramDialog(QDialog):
         discord_btn.setText("Discord")
         discord_btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
         discord_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-        discord_btn.setStyleSheet("QToolButton { color: #007AFF; font-size: 14px; font-weight: 500; background: none; border: none; padding: 4px 8px; } QToolButton:hover { text-decoration: underline; }")
+        discord_btn.setStyleSheet(f"QToolButton {{ color: {c.accent}; font-size: 14px; font-weight: 500; background: none; border: none; padding: 4px 8px; }} QToolButton:hover {{ text-decoration: underline; }}")
         discord_btn.clicked.connect(lambda: QDesktopServices.openUrl(QUrl("https://discord.gg/Rm6r4zeE3y")))
         links_layout.addWidget(discord_btn)
         
         layout.addLayout(links_layout)
         layout.addWidget(self.buttonBox)
         self.setLayout(layout)
+
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        self.setStyleSheet(f"""
+            QDialog {{ background-color: {c.bg_elevated}; }}
+            QDialogButtonBox QPushButton {{
+                background-color: {c.accent};
+                border-radius: 10px;
+                color: {c.text_primary};
+                font-size: 15px;
+                font-weight: 600;
+                padding: 10px 24px;
+                border: none;
+            }}
+            QDialogButtonBox QPushButton:hover {{ background-color: {c.accent_hover}; }}
+        """)
 
 
 class UpdateAppDialog(QDialog):

--- a/src/gui/dialogs/tendie_preview_dialog.py
+++ b/src/gui/dialogs/tendie_preview_dialog.py
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import QDialog, QLabel, QPushButton, QVBoxLayout
 from src.gui.ios.phone_frame import (
     DEVICE_PT_H, DEVICE_PT_W, PhoneFrame,
 )
+from src.gui.theme import ColorThemeManager
 
 _MAX_EDGE = 2556  # downscale wallpapers to the iPhone 15 native long edge
 
@@ -51,21 +52,22 @@ class TendiePreviewDialog(QDialog):
         self._frame.setFixedSize(frame_w, frame_h)
         layout.addWidget(self._frame, 0, Qt.AlignmentFlag.AlignHCenter)
 
+        c = ColorThemeManager.instance().colors
         self._hint = QLabel(QCoreApplication.translate(
             "Nugget", "Loading preview..."))
         self._hint.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._hint.setWordWrap(True)
         self._hint.setStyleSheet(
-            "color: #8E8E93; font-size: 12px; background: transparent;")
+            f"color: {c.text_secondary}; font-size: 12px; background: transparent;")
         layout.addWidget(self._hint)
 
         self._variant_btn = QPushButton()
         self._variant_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         self._variant_btn.setStyleSheet(
-            "QPushButton { background-color: #3A3A3C; color: white; "
+            f"QPushButton {{ background-color: {c.border}; color: {c.text_inverse}; "
             "border: none; border-radius: 12px; padding: 10px 24px; "
             "font-size: 14px; }"
-            "QPushButton:hover { background-color: #48484A; }")
+            f"QPushButton:hover {{ background-color: {c.scrollbar_pressed}; }}")
         self._variant_btn.clicked.connect(self._toggle_appearance)
         self._variant_btn.hide()
         layout.addWidget(self._variant_btn, 0, Qt.AlignmentFlag.AlignHCenter)
@@ -73,14 +75,25 @@ class TendiePreviewDialog(QDialog):
         close_btn = QPushButton(QCoreApplication.translate("Nugget", "Close"))
         close_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         close_btn.setStyleSheet(
-            "QPushButton { background-color: #3A3A3C; color: white; "
+            f"QPushButton {{ background-color: {c.border}; color: {c.text_inverse}; "
             "border: none; border-radius: 12px; padding: 10px 24px; "
             "font-size: 14px; }"
-            "QPushButton:hover { background-color: #48484A; }")
+            f"QPushButton:hover {{ background-color: {c.scrollbar_pressed}; }}")
         close_btn.clicked.connect(self.reject)
         layout.addWidget(close_btn, 0, Qt.AlignmentFlag.AlignHCenter)
 
         self._load()
+
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        self._hint.setStyleSheet(
+            f"color: {c.text_secondary}; font-size: 12px; background: transparent;")
+        btn_style = (
+            f"QPushButton {{ background-color: {c.border}; color: {c.text_inverse}; "
+            "border: none; border-radius: 12px; padding: 10px 24px; "
+            "font-size: 14px; }"
+            f"QPushButton:hover {{ background-color: {c.scrollbar_pressed}; }}")
+        self._variant_btn.setStyleSheet(btn_style)
 
     # ---- loading -------------------------------------------------------
 

--- a/src/gui/dialogs/wallpaper_downloader.py
+++ b/src/gui/dialogs/wallpaper_downloader.py
@@ -25,6 +25,7 @@ from PySide6.QtWidgets import (
 )
 
 from src.tweaks.tweaks import tweaks, TweakID
+from src.gui.theme import ColorThemeManager
 
 
 CARD_W = 150
@@ -43,17 +44,7 @@ class _WallpaperCard(QFrame):
         self._on_click_cb = on_click
         self.setCursor(Qt.PointingHandCursor)
         self.setObjectName("wallpaperCard")
-        self.setStyleSheet("""
-            QFrame#wallpaperCard {
-                background-color: #1C1C1E;
-                border-radius: 12px;
-                border: none;
-            }
-            QFrame#wallpaperCard:hover { background-color: #2C2C2E; }
-            QLabel#wpName { color: #FFFFFF; font-size: 13px; font-weight: 600; }
-            QLabel#wpAuthor { color: #8E8E93; font-size: 11px; }
-            QLabel#wpPreview { background-color: #26262A; border-radius: 8px; }
-        """)
+        self._retheme()
         self.setFixedSize(CARD_W, CARD_H)
 
         layout = QVBoxLayout(self)
@@ -87,18 +78,34 @@ class _WallpaperCard(QFrame):
 
         layout.addStretch()
 
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        self.setStyleSheet(f"""
+            QFrame#wallpaperCard {{
+                background-color: {c.bg_secondary};
+                border-radius: 12px;
+                border: none;
+            }}
+            QFrame#wallpaperCard:hover {{ background-color: {c.surface_hover}; }}
+            QLabel#wpName {{ color: {c.text_primary}; font-size: 13px; font-weight: 600; }}
+            QLabel#wpAuthor {{ color: {c.text_secondary}; font-size: 11px; }}
+            QLabel#wpPreview {{ background-color: {c.bg_tertiary}; border-radius: 8px; }}
+        """)
+
     def _set_loading(self):
+        c = ColorThemeManager.instance().colors
         self.preview_lbl.setText(QCoreApplication.translate("Nugget", "Loading..."))
         self.preview_lbl.setStyleSheet(
-            "background-color: #26262A; border-radius: 8px;"
-            "font-size: 13px; color: #6E6E73;"
+            f"background-color: {c.bg_tertiary}; border-radius: 8px;"
+            f"font-size: 13px; color: {c.text_disabled};"
         )
 
     def _set_placeholder(self):
+        c = ColorThemeManager.instance().colors
         self.preview_lbl.setText("\U0001F5BC\ufe0f")
         self.preview_lbl.setStyleSheet(
-            "background-color: #26262A; border-radius: 8px;"
-            "font-size: 34px; color: #3A3A3C;"
+            f"background-color: {c.bg_tertiary}; border-radius: 8px;"
+            f"font-size: 34px; color: {c.border};"
         )
 
     def set_preview_file(self, path):
@@ -177,44 +184,7 @@ class WallpaperDownloaderDialog(QDialog):
         self.setWindowTitle(QCoreApplication.translate("Nugget", "Download Wallpapers"))
         self.setModal(True)
         self.setFixedSize(760, 780)
-        self.setStyleSheet("""
-            QDialog { background-color: #1e1e1e; }
-            QLabel { color: #FFFFFF; }
-            QComboBox {
-                background-color: #1C1C1E;
-                border: none;
-                border-radius: 10px;
-                color: #FFFFFF;
-                font-size: 14px;
-                padding: 8px 12px;
-                min-height: 24px;
-            }
-            QComboBox::drop-down { border: none; width: 24px; }
-            QComboBox QAbstractItemView {
-                background-color: #2C2C2E;
-                border: 1px solid #3A3A3C;
-                border-radius: 10px;
-                color: #FFFFFF;
-                selection-background-color: #007AFF;
-            }
-            QLineEdit {
-                background-color: #1C1C1E;
-                border: none;
-                border-radius: 10px;
-                color: #FFFFFF;
-                font-size: 14px;
-                padding: 8px 12px;
-            }
-            QScrollArea { background: transparent; border: none; }
-            QProgressBar {
-                background-color: #1C1C1E;
-                border-radius: 4px;
-                border: none;
-                height: 7px;
-                text-align: center;
-            }
-            QProgressBar::chunk { background-color: #007AFF; border-radius: 4px; }
-        """)
+        self._retheme()
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(16, 16, 16, 16)
@@ -244,8 +214,9 @@ class WallpaperDownloaderDialog(QDialog):
         layout.addLayout(top)
 
         # Status / progress area
+        c = ColorThemeManager.instance().colors
         self.status_lbl = QLabel(QCoreApplication.translate("Nugget", "Loading..."))
-        self.status_lbl.setStyleSheet("color: #8E8E93; font-size: 13px;")
+        self.status_lbl.setStyleSheet(f"color: {c.text_secondary}; font-size: 13px;")
         layout.addWidget(self.status_lbl)
 
         self.progress = QProgressBar()
@@ -269,17 +240,17 @@ class WallpaperDownloaderDialog(QDialog):
         # Bottom close button
         close_btn = QPushButton(QCoreApplication.translate("Nugget", "Close"))
         close_btn.setCursor(Qt.PointingHandCursor)
-        close_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #007AFF;
+        close_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {c.accent};
                 border-radius: 12px;
-                color: #FFFFFF;
+                color: {c.text_primary};
                 font-size: 16px;
                 font-weight: 600;
                 padding: 12px;
                 border: none;
-            }
-            QPushButton:hover { background-color: #0066CC; }
+            }}
+            QPushButton:hover {{ background-color: {c.accent_hover}; }}
         """)
         close_btn.clicked.connect(self.accept)
         layout.addWidget(close_btn)
@@ -311,6 +282,47 @@ class WallpaperDownloaderDialog(QDialog):
 
         self._populate_categories()
         self._fetch_wallpapers()
+
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        self.setStyleSheet(f"""
+            QDialog {{ background-color: {c.bg_elevated}; }}
+            QLabel {{ color: {c.text_primary}; }}
+            QComboBox {{
+                background-color: {c.bg_secondary};
+                border: none;
+                border-radius: 10px;
+                color: {c.text_primary};
+                font-size: 14px;
+                padding: 8px 12px;
+                min-height: 24px;
+            }}
+            QComboBox::drop-down {{ border: none; width: 24px; }}
+            QComboBox QAbstractItemView {{
+                background-color: {c.surface_hover};
+                border: 1px solid {c.border};
+                border-radius: 10px;
+                color: {c.text_primary};
+                selection-background-color: {c.accent};
+            }}
+            QLineEdit {{
+                background-color: {c.bg_secondary};
+                border: none;
+                border-radius: 10px;
+                color: {c.text_primary};
+                font-size: 14px;
+                padding: 8px 12px;
+            }}
+            QScrollArea {{ background: transparent; border: none; }}
+            QProgressBar {{
+                background-color: {c.bg_secondary};
+                border-radius: 4px;
+                border: none;
+                height: 7px;
+                text-align: center;
+            }}
+            QProgressBar::chunk {{ background-color: {c.accent}; border-radius: 4px; }}
+        """)
 
     # --- source / category handling ---
 

--- a/src/gui/interface_picker.py
+++ b/src/gui/interface_picker.py
@@ -7,6 +7,8 @@ from PySide6.QtWidgets import (
 
 import os
 
+from src.gui.theme import ColorThemeManager
+
 _ICON_DIR = os.path.join(os.path.dirname(__file__), "..", "qt", "icon")
 
 
@@ -29,10 +31,6 @@ class InterfacePickerDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle(QCoreApplication.translate("Nugget", "Choose Interface"))
         self.setFixedWidth(420)
-        self.setStyleSheet("""
-            QDialog { background-color: #1e1e1e; }
-            QLabel { color: #FFFFFF; background: transparent; }
-        """)
         self.choice = None  # "classic" | "ios"
 
         layout = QVBoxLayout(self)
@@ -44,21 +42,16 @@ class InterfacePickerDialog(QDialog):
         title.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(title)
 
-        subtitle = QLabel(QCoreApplication.translate(
+        self._subtitle = QLabel(QCoreApplication.translate(
             "Nugget", "Choose your interface style"))
-        subtitle.setStyleSheet("color: #8E8E93; font-size: 14px;")
-        subtitle.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        layout.addWidget(subtitle)
+        self._subtitle.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self._subtitle)
 
         layout.addSpacing(8)
 
         # Classic option
-        classic_frame = QFrame()
-        classic_frame.setStyleSheet("""
-            QFrame { background-color: #2C2C2E; border-radius: 12px; }
-            QFrame:hover { background-color: #3A3A3C; }
-        """)
-        cf_lay = QVBoxLayout(classic_frame)
+        self._classic_frame = QFrame()
+        cf_lay = QVBoxLayout(self._classic_frame)
         cf_lay.setContentsMargins(16, 12, 16, 12)
         classic_art = QLabel()
         classic_art.setPixmap(_render_svg(
@@ -68,23 +61,18 @@ class InterfacePickerDialog(QDialog):
         cf_lay.addWidget(classic_art)
         cf_title = QLabel(QCoreApplication.translate("Nugget", "Classic"))
         cf_title.setStyleSheet("font-size: 16px; font-weight: 600; border: none;")
-        cf_desc = QLabel(QCoreApplication.translate(
+        self._cf_desc = QLabel(QCoreApplication.translate(
             "Nugget", "Sidebar navigation with familiar layout"))
-        cf_desc.setStyleSheet("color: #8E8E93; font-size: 13px; border: none;")
-        cf_desc.setWordWrap(True)
+        self._cf_desc.setWordWrap(True)
         cf_lay.addWidget(cf_title)
-        cf_lay.addWidget(cf_desc)
-        classic_frame.setCursor(Qt.CursorShape.PointingHandCursor)
-        classic_frame.mousePressEvent = lambda e: self._pick("classic")
-        layout.addWidget(classic_frame)
+        cf_lay.addWidget(self._cf_desc)
+        self._classic_frame.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._classic_frame.mousePressEvent = lambda e: self._pick("classic")
+        layout.addWidget(self._classic_frame)
 
         # iOS-style option
-        ios_frame = QFrame()
-        ios_frame.setStyleSheet("""
-            QFrame { background-color: #2C2C2E; border-radius: 12px; }
-            QFrame:hover { background-color: #3A3A3C; }
-        """)
-        io_lay = QVBoxLayout(ios_frame)
+        self._ios_frame = QFrame()
+        io_lay = QVBoxLayout(self._ios_frame)
         io_lay.setContentsMargins(16, 12, 16, 12)
         ios_art = QLabel()
         ios_art.setPixmap(_render_svg(
@@ -94,15 +82,35 @@ class InterfacePickerDialog(QDialog):
         io_lay.addWidget(ios_art)
         io_title = QLabel(QCoreApplication.translate("Nugget", "iOS-style"))
         io_title.setStyleSheet("font-size: 16px; font-weight: 600; border: none;")
-        io_desc = QLabel(QCoreApplication.translate(
+        self._io_desc = QLabel(QCoreApplication.translate(
             "Nugget", "Full-screen mobile-inspired interface"))
-        io_desc.setStyleSheet("color: #8E8E93; font-size: 13px; border: none;")
-        io_desc.setWordWrap(True)
+        self._io_desc.setWordWrap(True)
         io_lay.addWidget(io_title)
-        io_lay.addWidget(io_desc)
-        ios_frame.setCursor(Qt.CursorShape.PointingHandCursor)
-        ios_frame.mousePressEvent = lambda e: self._pick("ios")
-        layout.addWidget(ios_frame)
+        io_lay.addWidget(self._io_desc)
+        self._ios_frame.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._ios_frame.mousePressEvent = lambda e: self._pick("ios")
+        layout.addWidget(self._ios_frame)
+
+        self._retheme()
+        ColorThemeManager.instance().theme_changed.connect(self._retheme)
+
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        self.setStyleSheet(f"""
+            QDialog {{ background-color: {c.bg_elevated}; }}
+            QLabel {{ color: {c.text_primary}; background: transparent; }}
+        """)
+        self._subtitle.setStyleSheet(f"color: {c.text_secondary}; font-size: 14px;")
+        self._classic_frame.setStyleSheet(f"""
+            QFrame {{ background-color: {c.surface_hover}; border-radius: 12px; }}
+            QFrame:hover {{ background-color: {c.border}; }}
+        """)
+        self._cf_desc.setStyleSheet(f"color: {c.text_secondary}; font-size: 13px; border: none;")
+        self._ios_frame.setStyleSheet(f"""
+            QFrame {{ background-color: {c.surface_hover}; border-radius: 12px; }}
+            QFrame:hover {{ background-color: {c.border}; }}
+        """)
+        self._io_desc.setStyleSheet(f"color: {c.text_secondary}; font-size: 13px; border: none;")
 
     def _pick(self, choice: str):
         self.choice = choice

--- a/src/gui/ios/apply.py
+++ b/src/gui/ios/apply.py
@@ -4,6 +4,7 @@ from PySide6.QtWidgets import (
 )
 
 from src.gui.ios.components import IOSSectionHeader, IOSCard, IOSPrimaryButton
+from src.gui.theme import ColorThemeManager
 
 
 class IOSApplyPage(QWidget):
@@ -20,7 +21,9 @@ class IOSApplyPage(QWidget):
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
-        scroll.setStyleSheet("background-color: #1e1e1e; border: none;")
+        c = ColorThemeManager.instance().colors
+        scroll.setStyleSheet(f"background-color: {c.bg_primary}; border: none;")
+        self._scroll = scroll
         content = QWidget()
         scroll.setWidget(content)
         layout.addWidget(scroll)
@@ -43,7 +46,8 @@ class IOSApplyPage(QWidget):
             "Applies every enabled tweak to your device. The device reboots "
             "when done — remember to turn Find My back on afterwards."))
         apply_desc.setWordWrap(True)
-        apply_desc.setStyleSheet("color: #8E8E93; font-size: 13px;")
+        apply_desc.setStyleSheet(f"color: {c.text_secondary}; font-size: 13px;")
+        self.apply_desc = apply_desc
         apply_layout.addWidget(apply_desc)
 
         self.apply_btn = IOSPrimaryButton(QCoreApplication.translate(
@@ -65,7 +69,8 @@ class IOSApplyPage(QWidget):
             "Nugget",
             "Restores the original values for the tweak pages you pick."))
         remove_desc.setWordWrap(True)
-        remove_desc.setStyleSheet("color: #8E8E93; font-size: 13px;")
+        remove_desc.setStyleSheet(f"color: {c.text_secondary}; font-size: 13px;")
+        self.remove_desc = remove_desc
         remove_layout.addWidget(remove_desc)
 
         self.remove_btn = IOSPrimaryButton(QCoreApplication.translate(
@@ -86,7 +91,7 @@ class IOSApplyPage(QWidget):
         self.status_lbl = QLabel("")
         self.status_lbl.setWordWrap(True)
         self.status_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.status_lbl.setStyleSheet("color: #FFFFFF; font-size: 14px;")
+        self.status_lbl.setStyleSheet(f"color: {c.text_primary}; font-size: 14px;")
         status_layout.addWidget(self.status_lbl)
         content_layout.addWidget(status_card)
 
@@ -98,3 +103,10 @@ class IOSApplyPage(QWidget):
     def set_busy(self, busy: bool):
         self.apply_btn.setEnabled(not busy)
         self.remove_btn.setEnabled(not busy)
+
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        self._scroll.setStyleSheet(f"background-color: {c.bg_primary}; border: none;")
+        self.apply_desc.setStyleSheet(f"color: {c.text_secondary}; font-size: 13px;")
+        self.remove_desc.setStyleSheet(f"color: {c.text_secondary}; font-size: 13px;")
+        self.status_lbl.setStyleSheet(f"color: {c.text_primary}; font-size: 14px;")

--- a/src/gui/ios/components.py
+++ b/src/gui/ios/components.py
@@ -5,6 +5,13 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
+from src.gui.theme import t, ColorThemeManager
+
+
+def _auto_retheme(widget):
+    """Connect a widget's ``_retheme`` to the global theme_changed signal."""
+    ColorThemeManager.instance().theme_changed.connect(widget._retheme)
+
 
 class TextInputDialog(QDialog):
     """iOS-style text input dialog."""
@@ -13,29 +20,7 @@ class TextInputDialog(QDialog):
         self.setWindowTitle(title)
         self.setModal(True)
         self.setMinimumWidth(320)
-        self.setStyleSheet("""
-            QDialog { background-color: #1e1e1e; }
-            QLabel { color: #FFFFFF; font-size: 15px; }
-            QLineEdit {
-                background-color: #1C1C1E;
-                border: none;
-                border-radius: 10px;
-                color: #FFFFFF;
-                font-size: 15px;
-                padding: 12px 16px;
-            }
-            QPushButton {
-                background-color: #007AFF;
-                border-radius: 10px;
-                color: #FFFFFF;
-                font-size: 15px;
-                font-weight: 600;
-                padding: 12px 24px;
-                border: none;
-                min-width: 80px;
-            }
-            QPushButton:hover { background-color: #0066CC; }
-        """)
+        self._retheme()
 
         layout = QVBoxLayout(self)
         layout.setSpacing(16)
@@ -49,20 +34,11 @@ class TextInputDialog(QDialog):
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
-        buttons.setStyleSheet("""
-            QPushButton {
-                background-color: #007AFF;
-                border-radius: 10px;
-                color: #FFFFFF;
-                font-size: 15px;
-                font-weight: 600;
-                padding: 12px 24px;
-                border: none;
-                min-width: 80px;
-            }
-            QPushButton:hover { background-color: #0066CC; }
-        """)
+        buttons.setStyleSheet(t("text_input_dialog"))
         layout.addWidget(buttons)
+
+    def _retheme(self):
+        self.setStyleSheet(t("text_input_dialog"))
 
     def get_value(self) -> str:
         return self.input.text()
@@ -75,30 +51,7 @@ class NumberInputDialog(QDialog):
         self.setWindowTitle(title)
         self.setModal(True)
         self.setMinimumWidth(320)
-        self.setStyleSheet("""
-            QDialog { background-color: #1e1e1e; }
-            QLabel { color: #FFFFFF; font-size: 15px; }
-            QSpinBox {
-                background-color: #1C1C1E;
-                border: none;
-                border-radius: 10px;
-                color: #FFFFFF;
-                font-size: 15px;
-                padding: 12px 16px;
-            }
-            QSpinBox::up-button, QSpinBox::down-button { width: 0; }
-            QPushButton {
-                background-color: #007AFF;
-                border-radius: 10px;
-                color: #FFFFFF;
-                font-size: 15px;
-                font-weight: 600;
-                padding: 12px 24px;
-                border: none;
-                min-width: 80px;
-            }
-            QPushButton:hover { background-color: #0066CC; }
-        """)
+        self._retheme()
 
         layout = QVBoxLayout(self)
         layout.setSpacing(16)
@@ -108,15 +61,16 @@ class NumberInputDialog(QDialog):
         self.spin.setRange(min_val, max_val)
         self.spin.setValue(current_value)
         self.spin.setButtonSymbols(QSpinBox.NoButtons)
-        self.spin.setStyleSheet("""
-            QSpinBox {
-                background-color: #1C1C1E;
+        c = ColorThemeManager.instance().colors
+        self.spin.setStyleSheet(f"""
+            QSpinBox {{
+                background-color: {c.bg_input};
                 border: none;
                 border-radius: 10px;
-                color: #FFFFFF;
+                color: {c.text_primary};
                 font-size: 15px;
                 padding: 12px 16px;
-            }
+            }}
         """)
         layout.addWidget(self.spin)
 
@@ -124,6 +78,24 @@ class NumberInputDialog(QDialog):
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
+
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        self.setStyleSheet(f"""
+            QDialog {{ background-color: {c.bg_elevated}; }}
+            QLabel {{ color: {c.text_primary}; font-size: 15px; }}
+            QPushButton {{
+                background-color: {c.accent};
+                border-radius: 10px;
+                color: {c.text_inverse};
+                font-size: 15px;
+                font-weight: 600;
+                padding: 12px 24px;
+                border: none;
+                min-width: 80px;
+            }}
+            QPushButton:hover {{ background-color: {c.accent_hover}; }}
+        """)
 
     def get_value(self) -> int:
         return self.spin.value()
@@ -134,7 +106,11 @@ class IOSSectionHeader(QLabel):
         super().__init__(text, parent)
         self.setObjectName("iosSectionHeader")
         self.setProperty("cls", "iosSectionHeader")
-        self.setStyleSheet("font-size: 13px; font-weight: 600; color: #8E8E93; text-transform: uppercase; letter-spacing: 0.5px; padding-left: 4px;")
+        self._retheme()
+        _auto_retheme(self)
+
+    def _retheme(self):
+        self.setStyleSheet(t("section_header"))
 
 
 class IOSCard(QFrame):
@@ -142,24 +118,16 @@ class IOSCard(QFrame):
         super().__init__(parent)
         self.setObjectName("iosCard")
         self.setFrameShape(QFrame.StyledPanel)
-        self.setStyleSheet("""
-            IOSCard {
-                background-color: #1C1C1E;
-                border-radius: 12px;
-                border: none;
-            }
-        """)
+        self._retheme()
+        _auto_retheme(self)
         # Don't create a default layout - let the caller decide
+
+    def _retheme(self):
+        self.setStyleSheet(t("card"))
 
 
 class IOSNavBar(QWidget):
-    """Reusable navigation header.
-
-    One shared instance lives in the main window and is reconfigured per
-    page (title / back visibility / right action) instead of every page
-    building its own. Safe to reconfigure any number of times — the layout
-    structure is built once and only contents/visibility change.
-    """
+    """Reusable navigation header."""
     def __init__(self, title: str = "", on_back=None, right_action=None,
                  window=None, parent=None):
         super().__init__(parent)
@@ -167,40 +135,29 @@ class IOSNavBar(QWidget):
         self.setFixedHeight(56)
         self.setSizePolicy(QSizePolicy.Policy.Expanding,
                            QSizePolicy.Policy.Fixed)
-        self.setStyleSheet("background-color: #1C1C1E; border-bottom: 1px solid #3A3A3C;")
         self._on_back = on_back or (window._go_back if hasattr(window, "_go_back") else None)
+        c = ColorThemeManager.instance().colors
+        self.setStyleSheet(t("nav_bar"))
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(16, 8, 16, 8)
         layout.setSpacing(0)
 
-        # left padding keeps the title centered when the back button hides
         self._left_pad = QWidget(self)
         self._left_pad.setFixedWidth(90)
         layout.addWidget(self._left_pad)
 
         self.back_btn = QPushButton(QCoreApplication.translate("Nugget", "←  Back"), self)
         self.back_btn.setCursor(Qt.PointingHandCursor)
-        self.back_btn.setStyleSheet("""
-            QPushButton {
-                background: transparent;
-                color: #007AFF;
-                font-size: 17px;
-                font-weight: 400;
-                border: none;
-                padding: 8px 0;
-            }
-            QPushButton:hover { color: #0066CC; }
-        """)
+        self.back_btn.setStyleSheet(t("nav_back_btn"))
         self.back_btn.clicked.connect(self._handle_back)
         layout.addWidget(self.back_btn)
 
         self.title_lbl = QLabel(title, self)
         self.title_lbl.setAlignment(Qt.AlignCenter)
-        self.title_lbl.setStyleSheet("font-size: 17px; font-weight: 600; color: #FFFFFF;")
+        self.title_lbl.setStyleSheet(t("nav_title"))
         layout.addWidget(self.title_lbl, 1)
 
-        # persistent right slot; contents are swapped per page
         self._right_box = QWidget(self)
         self._right_layout = QHBoxLayout(self._right_box)
         self._right_layout.setContentsMargins(0, 0, 0, 0)
@@ -208,30 +165,29 @@ class IOSNavBar(QWidget):
         layout.addWidget(self._right_box)
         self._right_btn = None
         self._left_pad.setVisible(False)
+        _auto_retheme(self)
+
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        self.setStyleSheet(t("nav_bar"))
+        self.back_btn.setStyleSheet(t("nav_back_btn"))
+        self.title_lbl.setStyleSheet(t("nav_title"))
+        if self._right_btn:
+            self._right_btn.setStyleSheet(t("nav_right_btn"))
 
     def set_title(self, title: str):
         self.title_lbl.setText(title)
 
     def set_back_visible(self, visible: bool):
         self.back_btn.setVisible(visible)
-        # pad only when there is no button, so the title stays centered
         self._left_pad.setVisible(not visible)
 
     def set_right_action(self, label_text: str, callback):
         self._clear_right()
+        c = ColorThemeManager.instance().colors
         btn = QPushButton(label_text, self)
         btn.setCursor(Qt.PointingHandCursor)
-        btn.setStyleSheet("""
-            QPushButton {
-                background: transparent;
-                color: #007AFF;
-                font-size: 15px;
-                font-weight: 600;
-                border: none;
-                padding: 8px 0;
-            }
-            QPushButton:hover { color: #0066CC; }
-        """)
+        btn.setStyleSheet(t("nav_right_btn"))
         btn.clicked.connect(callback)
         self._right_layout.addWidget(btn)
         self._right_btn = btn
@@ -242,8 +198,6 @@ class IOSNavBar(QWidget):
     def _clear_right(self):
         if self._right_btn is not None:
             self._right_layout.removeWidget(self._right_btn)
-            # detach immediately: deleteLater alone may outlive the caller's
-            # processEvents pass, leaving a phantom button on screen
             self._right_btn.setParent(None)
             self._right_btn.deleteLater()
             self._right_btn = None
@@ -259,18 +213,11 @@ class IOSSettingsRow(QPushButton):
         self.setObjectName("iosSettingsRow")
         self.setCursor(Qt.PointingHandCursor)
         self.setText(f"{title}  ›")
-        self.setStyleSheet("""
-            QPushButton {
-                background-color: #1C1C1E;
-                border-radius: 10px;
-                color: #FFFFFF;
-                font-size: 15px;
-                text-align: left;
-                padding: 14px 16px;
-                border: none;
-            }
-            QPushButton:hover { background-color: #2C2C2E; }
-        """)
+        self._retheme()
+        _auto_retheme(self)
+
+    def _retheme(self):
+        self.setStyleSheet(t("settings_row"))
 
 
 class IOSPrimaryButton(QPushButton):
@@ -279,19 +226,11 @@ class IOSPrimaryButton(QPushButton):
         self.setObjectName("iosPrimaryButton")
         self.setCursor(Qt.PointingHandCursor)
         self.setFixedHeight(50)
-        self.setStyleSheet("""
-            QPushButton {
-                background-color: #007AFF;
-                border-radius: 12px;
-                color: #FFFFFF;
-                font-size: 17px;
-                font-weight: 600;
-                border: none;
-            }
-            QPushButton:hover { background-color: #0066CC; }
-            QPushButton:pressed { background-color: #0055AA; }
-            QPushButton:disabled { background-color: #3A3A3C; color: #8E8E93; }
-        """)
+        self._retheme()
+        _auto_retheme(self)
+
+    def _retheme(self):
+        self.setStyleSheet(t("primary_button"))
 
 
 class IOSSwitch(QPushButton):
@@ -305,19 +244,20 @@ class IOSSwitch(QPushButton):
         self._knob = QLabel(self)
         self._knob.setFixedSize(27, 27)
         self._knob.setAttribute(Qt.WA_TransparentForMouseEvents)
-        self._knob.setStyleSheet("background-color: #FFFFFF; border-radius: 13px; border: none;")
+        self._knob.setStyleSheet(t("switch_knob"))
         self.toggled.connect(self._update_style)
         self._update_style()
+        _auto_retheme(self)
+
+    def _retheme(self):
+        self._update_style()
+        self._knob.setStyleSheet(t("switch_knob"))
 
     def _update_style(self):
+        c = ColorThemeManager.instance().colors
         checked = self.isChecked()
-        self.setStyleSheet(f"""
-            QPushButton {{
-                background-color: {'#30D158' if checked else '#3A3A3C'};
-                border-radius: 15px;
-                border: none;
-            }}
-        """)
+        track = c.success if checked else c.border
+        self.setStyleSheet(f"QPushButton {{ background-color: {track}; border-radius: 15px; border: none; }}")
         self._knob.move(22 if checked else 2, 2)
 
 
@@ -325,5 +265,9 @@ class IOSValueLabel(QLabel):
     """Label showing current value in parentheses"""
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setStyleSheet("color: #8E8E93; font-size: 14px;")
+        self._retheme()
         self.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        _auto_retheme(self)
+
+    def _retheme(self):
+        self.setStyleSheet(t("value_label"))

--- a/src/gui/ios/daemons.py
+++ b/src/gui/ios/daemons.py
@@ -2,6 +2,7 @@ from PySide6.QtCore import QCoreApplication
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QScrollArea, QHBoxLayout, QLabel, QMessageBox
 
 from src.gui.ios.components import IOSSectionHeader, IOSSwitch
+from src.gui.theme import ColorThemeManager
 from src.tweaks.tweaks import tweaks, TweakID
 from src.tweaks.tweak_loader import load_daemons
 from src.tweaks.daemons_tweak import Daemon
@@ -33,8 +34,10 @@ class IOSDaemonsContent(QWidget):
         master_row = QHBoxLayout(master_card)
         master_row.setContentsMargins(16, 10, 16, 10)
         master_row.setSpacing(12)
+        c = ColorThemeManager.instance().colors
         master_label = QLabel(QCoreApplication.translate("Nugget", "Enable Daemon Modifications"))
-        master_label.setStyleSheet("color: #FFFFFF; font-size: 15px;")
+        master_label.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
+        self._master_label = master_label
         master_row.addWidget(master_label, 1)
         self.master_switch = IOSSwitch(self.daemons_tweak.enabled)
         self.master_switch.toggled.connect(self._on_master_toggled)
@@ -43,6 +46,8 @@ class IOSDaemonsContent(QWidget):
 
         self.daemon_cards = []
         self.daemon_switches = []
+        self._daemon_labels = []
+        self._forced_notes = []
         self._confirming = False
         self._hotload_acked = False
 
@@ -90,7 +95,8 @@ class IOSDaemonsContent(QWidget):
             row_layout.setContentsMargins(16, 10, 16, 10)
             row_layout.setSpacing(12)
             label = QLabel(QCoreApplication.translate("Nugget", "Clear ScreenTimeAgent.plist file"))
-            label.setStyleSheet("color: #FFFFFF; font-size: 15px;")
+            label.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
+            self._screen_time_label = label
             row_layout.addWidget(label, 1)
             self.screen_time_switch = IOSSwitch(self.screen_time_tweak.enabled)
             self.screen_time_switch.toggled.connect(self.screen_time_tweak.set_enabled)
@@ -106,8 +112,10 @@ class IOSDaemonsContent(QWidget):
         row_layout.setContentsMargins(16, 10, 16, 10)
         row_layout.setSpacing(12)
 
+        c = ColorThemeManager.instance().colors
         label = QLabel(title)
-        label.setStyleSheet("color: #FFFFFF; font-size: 15px;")
+        label.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
+        self._daemon_labels.append(label)
         row_layout.addWidget(label, 1)
 
         value = self.daemons_tweak.value.get(daemon.value[0], False) if self.daemons_tweak.value else False
@@ -124,7 +132,8 @@ class IOSDaemonsContent(QWidget):
             switch.setEnabled(False)
             self._forced_switches.append(switch)
             note = QLabel(QCoreApplication.translate("Nugget", "safety rules"))
-            note.setStyleSheet("color: #ff6b6b; font-size: 12px;")
+            note.setStyleSheet(f"color: {c.error}; font-size: 12px;")
+            self._forced_notes.append(note)
             row_layout.addWidget(note)
 
         layout.addWidget(card)
@@ -277,6 +286,16 @@ class IOSDaemonsContent(QWidget):
             screen_time_switch.setChecked(self.screen_time_tweak.enabled)
             screen_time_switch.blockSignals(False)
 
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        self._master_label.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
+        for lbl in self._daemon_labels:
+            lbl.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
+        for note in self._forced_notes:
+            note.setStyleSheet(f"color: {c.error}; font-size: 12px;")
+        if hasattr(self, '_screen_time_label'):
+            self._screen_time_label.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
+
 
 class IOSDaemonsPage(QWidget):
     def __init__(self, window, parent=None):
@@ -288,12 +307,19 @@ class IOSDaemonsPage(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
+        c = ColorThemeManager.instance().colors
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
-        scroll.setStyleSheet("background-color: #1e1e1e; border: none;")
+        scroll.setStyleSheet(f"background-color: {c.bg_primary}; border: none;")
+        self._scroll = scroll
         self.content = IOSDaemonsContent(window, self)
         scroll.setWidget(self.content)
         layout.addWidget(scroll)
 
     def refresh_from_tweaks(self):
         self.content.refresh_from_tweaks()
+
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        self._scroll.setStyleSheet(f"background-color: {c.bg_primary}; border: none;")
+        self.content._retheme()

--- a/src/gui/ios/home.py
+++ b/src/gui/ios/home.py
@@ -6,6 +6,7 @@ from PySide6.QtWidgets import (
 
 from src.gui.ios.components import IOSCard, IOSPrimaryButton
 from src.gui.preset_widget import PresetWidget
+from src.gui.theme import t, ColorThemeManager
 
 
 class IOSHomePage(QWidget):
@@ -13,6 +14,7 @@ class IOSHomePage(QWidget):
         super().__init__(parent)
         self.window = window
         self.setObjectName("iosContainer")
+        self._c = ColorThemeManager.instance().colors
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(16, 16, 16, 16)
@@ -23,90 +25,52 @@ class IOSHomePage(QWidget):
         header.setSpacing(16)
 
         # Load logo from resources
-        logo = QLabel(self)
-        logo.setFixedSize(80, 80)
-        logo.setScaledContents(True)
+        self._logo = QLabel(self)
+        self._logo.setFixedSize(80, 80)
+        self._logo.setScaledContents(True)
         pixmap = QPixmap(":/credits/big_nugget.png")
         if not pixmap.isNull():
-            logo.setPixmap(pixmap)
+            self._logo.setPixmap(pixmap)
         else:
-            logo.setStyleSheet("background-color: #1C1C1E; border-radius: 14px;")
-        header.addWidget(logo)
+            self._logo.setStyleSheet(f"background-color: {self._c.bg_secondary}; border-radius: 14px;")
+        header.addWidget(self._logo)
 
         title_layout = QVBoxLayout()
-        title = QLabel(QCoreApplication.translate("Nugget", "GoldenNugget"), self)
-        title.setStyleSheet("font-size: 32px; font-weight: 700; color: #FFFFFF;")
-        title_layout.addWidget(title)
+        self._title = QLabel(QCoreApplication.translate("Nugget", "GoldenNugget"), self)
+        self._title.setStyleSheet(t("home_title"))
+        title_layout.addWidget(self._title)
 
-        # Dynamic subtitle from device
         self.subtitle = QLabel(QCoreApplication.translate("Nugget", "iPhone (iOS —)"), self)
-        self.subtitle.setStyleSheet("font-size: 15px; color: #8E8E93;")
+        self.subtitle.setStyleSheet(t("home_subtitle"))
         title_layout.addWidget(self.subtitle)
         header.addLayout(title_layout, 1)
 
-        # Device picker - actual dropdown with devices
         self.device_combo = QComboBox(self)
         self.device_combo.setFixedHeight(36)
-        self.device_combo.setStyleSheet("""
-            QComboBox {
-                background-color: #1C1C1E;
-                border-radius: 18px;
-                color: #FFF;
-                padding: 0 16px;
-                font-size: 15px;
-            }
-            QComboBox::drop-down { border: none; }
-            QComboBox QAbstractItemView {
-                background-color: #1C1C1E;
-                color: #FFF;
-                selection-background-color: #007AFF;
-            }
-        """)
+        self._style_device_combo()
         self.populate_device_picker()
         self.device_combo.currentIndexChanged.connect(self.on_device_changed)
         header.addWidget(self.device_combo)
 
-        # Refresh button
-        refresh_btn = QPushButton("⟳", self)
-        refresh_btn.setFixedSize(36, 36)
-        refresh_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #1C1C1E;
-                border-radius: 18px;
-                color: #FFF;
-                font-size: 18px;
-                border: none;
-            }
-            QPushButton:hover { background-color: #2C2C2E; }
-        """)
-        refresh_btn.clicked.connect(self.refresh_devices)
-        header.addWidget(refresh_btn)
+        self._refresh_btn = QPushButton("⟳", self)
+        self._refresh_btn.setFixedSize(36, 36)
+        self._refresh_btn.setStyleSheet(t("home_icon_button"))
+        self._refresh_btn.clicked.connect(self.refresh_devices)
+        header.addWidget(self._refresh_btn)
 
-        # Settings button
-        settings_btn = QPushButton("⚙", self)
-        settings_btn.setFixedSize(36, 36)
-        settings_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #1C1C1E;
-                border-radius: 18px;
-                color: #FFF;
-                font-size: 18px;
-                border: none;
-            }
-            QPushButton:hover { background-color: #2C2C2E; }
-        """)
-        settings_btn.clicked.connect(self.open_settings)
-        header.addWidget(settings_btn)
+        self._settings_btn = QPushButton("⚙", self)
+        self._settings_btn.setFixedSize(36, 36)
+        self._settings_btn.setStyleSheet(t("home_icon_button"))
+        self._settings_btn.clicked.connect(self.open_settings)
+        header.addWidget(self._settings_btn)
 
         layout.addLayout(header)
 
-        # Status support label
         self.status_lbl = QLabel("", self)
         self.status_lbl.setWordWrap(True)
         self.status_lbl.setTextFormat(Qt.RichText)
         layout.addWidget(self.status_lbl)
 
-        # Three cards row: PosterBoard, Tweaks, Daemons
         cards_row = QHBoxLayout()
         cards_row.setSpacing(12)
 
@@ -124,42 +88,84 @@ class IOSHomePage(QWidget):
         cards_row.addWidget(self.statusbar_card, 1)
         layout.addLayout(cards_row)
 
-        # Apply Tweaks button
         apply_btn = IOSPrimaryButton(QCoreApplication.translate("Nugget", "Apply Tweaks"))
         apply_btn.clicked.connect(self.open_apply_classic)
         layout.addWidget(apply_btn)
 
-        # Reset Tweaks button
         reset_btn = IOSPrimaryButton(QCoreApplication.translate("Nugget", "Reset Tweaks"))
         reset_btn.clicked.connect(self.reset_tweaks)
         layout.addWidget(reset_btn)
 
-        # Presets widget: makes the active preset explicit and offers a quick
-        # path to the preset manager.
         self.preset_widget = PresetWidget(
             window=self.window, on_manage=self.open_presets_section, ios_style=True)
         layout.addWidget(self.preset_widget)
 
-        # Process status indicator (apply/reset progress + completion)
         self.process_status_lbl = QLabel("", self)
         self.process_status_lbl.setWordWrap(True)
         self.process_status_lbl.setAlignment(Qt.AlignCenter)
-        self.process_status_lbl.setStyleSheet("font-size: 14px; font-weight: 600; color: #30D158;")
+        self.process_status_lbl.setStyleSheet(t("process_status_green"))
         self.process_status_lbl.hide()
         layout.addWidget(self.process_status_lbl)
-        # Single auto-hide timer: restarted on every progress update so the
-        # label never hides mid-apply (stacked singleShot timers caused
-        # hide/show flicker on each progress tick).
         self._hide_timer = QTimer(self)
         self._hide_timer.setSingleShot(True)
         self._hide_timer.timeout.connect(self.hide_process_status)
 
         layout.addStretch()
 
-        # Initial update
         self.update_status()
         self.update_device_info()
         self.refresh_preset_widget()
+
+    def _style_device_combo(self):
+        c = self._c
+        self.device_combo.setStyleSheet(f"""
+            QComboBox {{
+                background-color: {c.bg_secondary};
+                border-radius: 18px;
+                color: {c.text_primary};
+                padding: 0 16px;
+                font-size: 15px;
+            }}
+            QComboBox::drop-down {{ border: none; }}
+            QComboBox QAbstractItemView {{
+                background-color: {c.bg_secondary};
+                color: {c.text_primary};
+                selection-background-color: {c.accent};
+            }}
+        """)
+
+    def _retheme(self):
+        self._c = ColorThemeManager.instance().colors
+        c = self._c
+        if self._logo.pixmap() is None or self._logo.pixmap().isNull():
+            self._logo.setStyleSheet(f"background-color: {c.bg_secondary}; border-radius: 14px;")
+        self._title.setStyleSheet(t("home_title"))
+        self.subtitle.setStyleSheet(t("home_subtitle"))
+        self._style_device_combo()
+        self._refresh_btn.setStyleSheet(t("home_icon_button"))
+        self._settings_btn.setStyleSheet(t("home_icon_button"))
+        self.process_status_lbl.setStyleSheet(t("process_status_green"))
+        self.update_status()
+        # Rebuild card headers for new colors
+        for card, title, sub_text in [
+            (self.posterboard_card, "PosterBoard", "Animated wallpapers & templates"),
+            (self.tweaks_card, "Tweaks", "Customize system settings"),
+            (self.daemons_card, "Daemons", "Disable system daemons"),
+            (self.statusbar_card, "Status Bar", "Customize the status bar"),
+        ]:
+            header = card.findChild(QFrame)
+            if header:
+                header.setStyleSheet(
+                    f"background-color: {c.bg_secondary}; border-top-left-radius: 12px; "
+                    f"border-top-right-radius: 12px;")
+            title_lbl = card.findChild(QLabel)
+            if title_lbl:
+                title_lbl.setStyleSheet(
+                    f"font-size: 17px; font-weight: 600; color: {c.text_primary};")
+            # Find subtitle label (second label in card)
+            labels = card.findChildren(QLabel)
+            if len(labels) > 1:
+                labels[1].setStyleSheet(f"font-size: 14px; color: {c.text_secondary};")
 
     def populate_device_picker(self):
         self.device_combo.blockSignals(True)
@@ -185,43 +191,34 @@ class IOSHomePage(QWidget):
 
     @Slot()
     def refresh_devices(self):
-        # Trigger refresh via main window
         self.window.refresh_devices()
 
     @Slot()
     def open_settings(self):
-        # Open iOS settings page within the iOS stack
-        self.window.ios_pages.setCurrentIndex(4)  # IOSSettingsPage
+        self.window.ios_pages.setCurrentIndex(4)
 
     def open_presets_section(self):
-        """Open settings and jump straight to the presets section."""
         self.window.open_presets_section()
 
     def switch_to_ios_page(self, index: int):
         self.window.ios_pages.setCurrentIndex(index)
 
     def open_apply_classic(self):
-        # Actually apply tweaks instead of just opening apply page
         self.window.apply_changes()
 
     def reset_tweaks(self):
-        """Reset tweaks using the classic reset dialog (select pages to reset)."""
         from src.gui.dialogs.reset_dialog import ResetDialog
         dialog = ResetDialog(device_manager=self.window.device_manager, apply_reset=self.window.apply_changes)
         dialog.exec()
 
     def show_process_status(self, text: str, success: bool = None):
-        """Show a status message for apply/reset operations.
-
-        ``success``: True -> green, False -> red, None -> neutral progress.
-        The message auto-hides after a few seconds.
-        """
+        c = self._c
         if success is True:
-            color = "#30D158"
+            color = c.success
         elif success is False:
-            color = "#FF453A"
+            color = c.error
         else:
-            color = "#007AFF"
+            color = c.accent
         self.process_status_lbl.setStyleSheet(
             f"font-size: 14px; font-weight: 600; color: {color};")
         self.process_status_lbl.setText(text)
@@ -232,20 +229,21 @@ class IOSHomePage(QWidget):
         self.process_status_lbl.hide()
 
     def update_status(self):
+        c = self._c
         try:
             if self.window.device_manager.get_current_device_udid():
                 if self.window.device_manager.get_current_device_partially_supported():
                     status_text = QCoreApplication.translate("Nugget", "Partially Supported")
-                    color = "#FFD60A"
+                    color = c.warning
                 else:
                     status_text = QCoreApplication.translate("QCoreApplication", "Supported!")
-                    color = "#30D158"
+                    color = c.success
             else:
                 status_text = QCoreApplication.translate("Nugget", "Not connected")
-                color = "#FFFFFF"
+                color = c.text_primary
         except AttributeError:
             status_text = QCoreApplication.translate("Nugget", "Not connected")
-            color = "#FFFFFF"
+            color = c.text_primary
         self.status_lbl.setText(f"<span style='color:{color};'>{status_text}</span>")
 
     def update_device_info(self):
@@ -260,14 +258,13 @@ class IOSHomePage(QWidget):
         self.populate_device_picker()
 
     def refresh_preset_widget(self):
-        """Update the active-preset banner (call after loading/saving a preset)."""
         self.preset_widget.refresh()
 
     def set_statusbar_visible(self, visible: bool):
         self.statusbar_card.setVisible(visible)
 
     def _make_card(self, title: str, subtitle: str, page_index: int) -> IOSCard:
-        """Build one of the feature shortcut cards (title + subtitle header)."""
+        c = self._c
         card = IOSCard()
         card_layout = QVBoxLayout(card)
         card_layout.setContentsMargins(0, 0, 0, 0)
@@ -276,13 +273,14 @@ class IOSHomePage(QWidget):
         header = QFrame()
         header.setFixedHeight(56)
         header.setStyleSheet(
-            "background-color: #1C1C1E; border-top-left-radius: 12px; "
-            "border-top-right-radius: 12px;")
+            f"background-color: {c.bg_secondary}; border-top-left-radius: 12px; "
+            f"border-top-right-radius: 12px;")
         header_layout = QHBoxLayout(header)
         header_layout.setContentsMargins(16, 8, 16, 8)
         header_title = QLabel(
             QCoreApplication.translate("Nugget", title), header)
-        header_title.setStyleSheet("font-size: 17px; font-weight: 600; color: #FFFFFF;")
+        header_title.setStyleSheet(
+            f"font-size: 17px; font-weight: 600; color: {c.text_primary};")
         header_layout.addWidget(header_title, 1, Qt.AlignCenter)
         card_layout.addWidget(header)
 
@@ -291,7 +289,7 @@ class IOSHomePage(QWidget):
         content_layout.setContentsMargins(16, 16, 16, 16)
         content_layout.setSpacing(8)
         sub = QLabel(QCoreApplication.translate("Nugget", subtitle), content)
-        sub.setStyleSheet("font-size: 14px; color: #8E8E93;")
+        sub.setStyleSheet(f"font-size: 14px; color: {c.text_secondary};")
         sub.setWordWrap(True)
         content_layout.addWidget(sub)
         card_layout.addWidget(content)

--- a/src/gui/ios/posterboard.py
+++ b/src/gui/ios/posterboard.py
@@ -10,6 +10,7 @@ from PySide6.QtGui import QPixmap, QIcon, QImageReader
 from PySide6.QtNetwork import QNetworkAccessManager, QNetworkRequest, QNetworkReply
 
 from src.gui.ios.components import IOSCard, IOSPrimaryButton
+from src.gui.theme import ColorThemeManager
 from src.tweaks.tweaks import tweaks, TweakID
 
 
@@ -20,12 +21,16 @@ class TemplatePreviewCard(QLabel):
         self.setAlignment(Qt.AlignCenter)
         self.setCursor(Qt.PointingHandCursor)
         self.setFixedSize(200, 200)
-        self.setStyleSheet(
-            "QLabel { background-color: #1C1C1E; border-radius: 12px; border: 1px solid #3A3A3C; }"
-        )
         self._original_pixmap = pixmap
         self._preview_name = preview_name
+        self._retheme()
         self.setPixmap(pixmap.scaled(190, 190, Qt.KeepAspectRatio, Qt.SmoothTransformation))
+
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        self.setStyleSheet(
+            f"QLabel {{ background-color: {c.bg_secondary}; border-radius: 12px; border: 1px solid {c.border}; }}"
+        )
 
 
 class IOSPosterboardPage(QWidget):
@@ -38,40 +43,24 @@ class IOSPosterboardPage(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
-        # the "+ Add Tendies" action lives in the shared header (main window)
-
-        # Reset PosterBoard card — emergency exit for a misbehaving or
-        # malformed PosterBoard database (see regression found in 8.3).
+        # Reset PosterBoard card
         reset_card = IOSCard()
         reset_layout = QVBoxLayout(reset_card)
         reset_layout.setContentsMargins(16, 12, 16, 12)
         reset_layout.setSpacing(8)
 
-        reset_btn = QPushButton(QCoreApplication.translate("Nugget", "Reset PosterBoard"))
-        reset_btn.setCursor(Qt.PointingHandCursor)
-        reset_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #3b3b3b;
-                border: none;
-                border-radius: 10px;
-                color: #FF453A;
-                font-size: 15px;
-                font-weight: 600;
-                padding: 12px;
-            }
-            QPushButton:hover { background-color: #4a4a4a; }
-        """)
-        reset_btn.clicked.connect(self._reset_posterboard)
-        reset_layout.addWidget(reset_btn)
+        self._reset_btn = QPushButton(QCoreApplication.translate("Nugget", "Reset PosterBoard"))
+        self._reset_btn.setCursor(Qt.PointingHandCursor)
+        self._reset_btn.clicked.connect(self._reset_posterboard)
+        reset_layout.addWidget(self._reset_btn)
 
-        reset_caption = QLabel(QCoreApplication.translate(
+        self._reset_caption = QLabel(QCoreApplication.translate(
             "Nugget",
             "Emergency reset for when PosterBoard behaves strangely or the "
             "database won't load after a restore. Resets on the next apply."
         ))
-        reset_caption.setWordWrap(True)
-        reset_caption.setStyleSheet("color: #8E8E93; font-size: 12px;")
-        reset_layout.addWidget(reset_caption)
+        self._reset_caption.setWordWrap(True)
+        reset_layout.addWidget(self._reset_caption)
 
         layout.addWidget(reset_card)
 
@@ -92,10 +81,9 @@ class IOSPosterboardPage(QWidget):
         self.tab_stack.addWidget(self.video_page)
 
         # Bottom tab bar
-        tab_bar = QWidget()
-        tab_bar.setFixedHeight(56)
-        tab_bar.setStyleSheet("background-color: #1e1e1e; border-top: 1px solid #1C1C1E;")
-        tab_layout = QHBoxLayout(tab_bar)
+        self._tab_bar = QWidget()
+        self._tab_bar.setFixedHeight(56)
+        tab_layout = QHBoxLayout(self._tab_bar)
         tab_layout.setContentsMargins(0, 0, 0, 0)
         tab_layout.setSpacing(0)
 
@@ -107,18 +95,138 @@ class IOSPosterboardPage(QWidget):
         tab_layout.addWidget(self.templates_tab_btn, 1)
         tab_layout.addWidget(self.video_tab_btn, 1)
 
-        layout.addWidget(tab_bar)
+        layout.addWidget(self._tab_bar)
 
-        # Set initial tab
-        self._switch_tab(0)
-
-        # Async preview-by-name loader for tendie cards (mirrors the
-        # wallpaper downloader: fetch -> cached file -> QImageReader frame).
         self._tendie_nam = QNetworkAccessManager(self)
         self._tendie_preview_replies = []
 
-        # Load existing tendies
+        self._retheme()
+        self._switch_tab(0)
         self.refresh_tendies()
+
+        ColorThemeManager.instance().theme_changed.connect(self._retheme)
+
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        self._reset_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {c.scrollbar};
+                border: none;
+                border-radius: 10px;
+                color: {c.error};
+                font-size: 15px;
+                font-weight: 600;
+                padding: 12px;
+            }}
+            QPushButton:hover {{ background-color: {c.surface_hover}; }}
+        """)
+        self._reset_caption.setStyleSheet(f"color: {c.text_secondary}; font-size: 12px;")
+        self._tab_bar.setStyleSheet(
+            f"background-color: {c.bg_primary}; border-top: 1px solid {c.bg_secondary};"
+        )
+        for btn in (self.tendies_tab_btn, self.templates_tab_btn, self.video_tab_btn):
+            btn.setStyleSheet(f"""
+                QToolButton {{
+                    background: transparent;
+                    color: {c.text_secondary};
+                    font-size: 11px;
+                    padding: 8px 0;
+                    border: none;
+                }}
+                QToolButton:checked {{
+                    color: {c.accent};
+                }}
+            """)
+        self._retheme_tendies_tab()
+        self._retheme_templates_tab()
+        self._retheme_video_tab()
+
+    def _retheme_tendies_tab(self):
+        c = ColorThemeManager.instance().colors
+        if hasattr(self, '_tendies_scroll'):
+            self._tendies_scroll.setStyleSheet(
+                f"background-color: {c.bg_primary}; border: none;"
+            )
+        if hasattr(self, '_download_icon'):
+            self._download_icon.setStyleSheet(
+                f"QLabel {{ background-color: {c.accent}; border-radius: 12px; font-size: 24px; color: {c.text_inverse}; }}"
+            )
+        if hasattr(self, '_download_title'):
+            self._download_title.setStyleSheet(
+                f"font-size: 16px; font-weight: 600; color: {c.text_primary};"
+            )
+        if hasattr(self, '_download_subtitle'):
+            self._download_subtitle.setStyleSheet(
+                f"font-size: 12px; color: {c.text_secondary};"
+            )
+        if hasattr(self, '_download_chevron'):
+            self._download_chevron.setStyleSheet(
+                f"font-size: 26px; color: {c.text_secondary};"
+            )
+        if hasattr(self, '_add_icon'):
+            self._add_icon.setStyleSheet(
+                f"QLabel {{ background-color: {c.bg_secondary}; border-radius: 12px; border: 2px dashed {c.border}; font-size: 36px; color: {c.accent}; }}"
+            )
+        if hasattr(self, '_add_label'):
+            self._add_label.setStyleSheet(
+                f"font-size: 14px; color: {c.text_secondary}; text-align: center;"
+            )
+
+    def _retheme_templates_tab(self):
+        c = ColorThemeManager.instance().colors
+        if hasattr(self, '_templates_scroll'):
+            self._templates_scroll.setStyleSheet(
+                f"background-color: {c.bg_primary}; border: none;"
+            )
+        if hasattr(self, 'templates_placeholder'):
+            self.templates_placeholder.setStyleSheet(
+                f"font-size: 15px; color: {c.text_secondary};"
+            )
+
+    def _retheme_video_tab(self):
+        c = ColorThemeManager.instance().colors
+        if hasattr(self, '_video_scroll'):
+            self._video_scroll.setStyleSheet(
+                f"background-color: {c.bg_primary}; border: none;"
+            )
+        for lbl in getattr(self, '_video_labels', []):
+            lbl.setStyleSheet(f"font-size: 15px; color: {c.text_primary}; min-width: 100px;")
+        for btn in (getattr(self, 'thumb_btn', None), getattr(self, 'video_btn', None)):
+            if btn is not None:
+                btn.setStyleSheet(f"""
+                    QPushButton {{
+                        background-color: {c.bg_secondary};
+                        border-radius: 10px;
+                        color: {c.accent};
+                        font-size: 15px;
+                        padding: 12px 24px;
+                        border: none;
+                    }}
+                    QPushButton:hover {{ background-color: {c.surface_hover}; }}
+                """)
+        for chk in (getattr(self, 'loop_chk', None), getattr(self, 'reverse_chk', None),
+                     getattr(self, 'foreground_chk', None)):
+            if chk is not None:
+                chk.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
+        if hasattr(self, 'calc_mode_drp'):
+            self.calc_mode_drp.setStyleSheet(f"""
+                QComboBox {{
+                    background-color: {c.bg_secondary};
+                    border: none;
+                    border-radius: 10px;
+                    color: {c.text_primary};
+                    font-size: 14px;
+                    padding: 8px 12px;
+                }}
+                QComboBox::drop-down {{ border: none; width: 24px; }}
+                QComboBox QAbstractItemView {{
+                    background-color: {c.surface_hover};
+                    border: 1px solid {c.border};
+                    border-radius: 10px;
+                    color: {c.text_primary};
+                    selection-background-color: {c.accent};
+                }}
+            """)
 
     def _make_tab_button(self, text: str, icon_path: str, index: int) -> QToolButton:
         btn = QToolButton()
@@ -130,18 +238,6 @@ class IOSPosterboardPage(QWidget):
         btn.setCheckable(True)
         btn.setAutoExclusive(True)
         btn.setCursor(Qt.PointingHandCursor)
-        btn.setStyleSheet("""
-            QToolButton {
-                background: transparent;
-                color: #8E8E93;
-                font-size: 11px;
-                padding: 8px 0;
-                border: none;
-            }
-            QToolButton:checked {
-                color: #007AFF;
-            }
-        """)
         btn.clicked.connect(lambda: self._switch_tab(index))
         return btn
 
@@ -152,28 +248,26 @@ class IOSPosterboardPage(QWidget):
         self.video_tab_btn.setChecked(index == 2)
 
     def _create_tendies_tab(self) -> QWidget:
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setStyleSheet("background-color: #1e1e1e; border: none;")
+        self._tendies_scroll = QScrollArea()
+        self._tendies_scroll.setWidgetResizable(True)
         content = QWidget()
-        scroll.setWidget(content)
+        self._tendies_scroll.setWidget(content)
 
         self.tendies_grid = QGridLayout(content)
         self.tendies_grid.setContentsMargins(16, 16, 16, 32)
         self.tendies_grid.setSpacing(12)
         self.tendies_grid.setAlignment(Qt.AlignTop)
 
-        # Download wallpapers banner (Cowabunga / CaPlayground)
         self.download_card = self._create_download_card()
         self.tendies_grid.addWidget(self.download_card, 0, 0, 1, 2)
 
-        # Add tendies button
         self.add_tendies_card = self._create_add_tendies_card()
         self.tendies_grid.addWidget(self.add_tendies_card, 1, 0)
 
-        return scroll
+        return self._tendies_scroll
 
     def _create_download_card(self) -> QWidget:
+        c = ColorThemeManager.instance().colors
         card = IOSCard()
         card.setCursor(Qt.PointingHandCursor)
         card.setMinimumHeight(88)
@@ -183,34 +277,29 @@ class IOSPosterboardPage(QWidget):
         inner.setContentsMargins(16, 12, 16, 12)
         inner.setSpacing(12)
 
-        icon = QLabel()
-        icon.setFixedSize(48, 48)
-        icon.setAlignment(Qt.AlignCenter)
-        icon.setStyleSheet(
-            "QLabel { background-color: #007AFF; border-radius: 12px; font-size: 24px; color: white; }"
-        )
-        icon.setText("\u2193")
-        inner.addWidget(icon)
+        self._download_icon = QLabel()
+        self._download_icon.setFixedSize(48, 48)
+        self._download_icon.setAlignment(Qt.AlignCenter)
+        self._download_icon.setText("\u2193")
+        inner.addWidget(self._download_icon)
 
         text_col = QVBoxLayout()
         text_col.setSpacing(2)
-        title = QLabel(QCoreApplication.translate("Nugget", "Download Wallpapers"))
-        title.setStyleSheet("font-size: 16px; font-weight: 600; color: #FFFFFF;")
-        text_col.addWidget(title)
-        subtitle = QLabel(QCoreApplication.translate(
+        self._download_title = QLabel(QCoreApplication.translate("Nugget", "Download Wallpapers"))
+        text_col.addWidget(self._download_title)
+        self._download_subtitle = QLabel(QCoreApplication.translate(
             "Nugget",
             "Browse and import wallpapers from Cowabunga and CaPlayground"))
-        subtitle.setStyleSheet("font-size: 12px; color: #8E8E93;")
-        text_col.addWidget(subtitle)
+        text_col.addWidget(self._download_subtitle)
         inner.addLayout(text_col, 1)
 
-        chevron = QLabel("\u203A")
-        chevron.setStyleSheet("font-size: 26px; color: #8E8E93;")
-        inner.addWidget(chevron)
+        self._download_chevron = QLabel("\u203A")
+        inner.addWidget(self._download_chevron)
 
         return card
 
     def _create_add_tendies_card(self) -> QWidget:
+        c = ColorThemeManager.instance().colors
         card = IOSCard()
         card.setFixedSize(140, 160)
         card.setCursor(Qt.PointingHandCursor)
@@ -221,55 +310,44 @@ class IOSPosterboardPage(QWidget):
         inner.setSpacing(12)
         inner.setAlignment(Qt.AlignCenter)
 
-        plus_icon = QLabel()
-        plus_icon.setFixedSize(64, 64)
-        plus_icon.setAlignment(Qt.AlignCenter)
-        plus_icon.setStyleSheet(
-            "QLabel { background-color: #1C1C1E; border-radius: 12px; border: 2px dashed #3A3A3C; }"
-        )
-        plus_icon.setText("+")
-        plus_icon.setStyleSheet(plus_icon.styleSheet() + "font-size: 36px; color: #007AFF;")
-        inner.addWidget(plus_icon, 0, Qt.AlignCenter)
+        self._add_icon = QLabel()
+        self._add_icon.setFixedSize(64, 64)
+        self._add_icon.setAlignment(Qt.AlignCenter)
+        self._add_icon.setText("+")
+        inner.addWidget(self._add_icon, 0, Qt.AlignCenter)
 
-        label = QLabel(QCoreApplication.translate("Nugget", "  Import Files (.tendies)"))
-        label.setStyleSheet("font-size: 14px; color: #8E8E93; text-align: center;")
-        label.setAlignment(Qt.AlignCenter)
-        inner.addWidget(label)
+        self._add_label = QLabel(QCoreApplication.translate("Nugget", "  Import Files (.tendies)"))
+        self._add_label.setAlignment(Qt.AlignCenter)
+        inner.addWidget(self._add_label)
 
         return card
 
     def _create_templates_tab(self) -> QWidget:
-        """Port of classic templates page - uses template.create_ui() for full functionality"""
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setStyleSheet("background-color: #1e1e1e; border: none;")
-        scroll.setFrameStyle(QScrollArea.NoFrame)
-        
+        self._templates_scroll = QScrollArea()
+        self._templates_scroll.setWidgetResizable(True)
+        self._templates_scroll.setFrameStyle(QScrollArea.NoFrame)
+
         content = QWidget()
         self.templates_layout = QVBoxLayout(content)
         self.templates_layout.setContentsMargins(16, 16, 16, 32)
         self.templates_layout.setSpacing(12)
         self.templates_layout.setAlignment(Qt.AlignTop)
-        scroll.setWidget(content)
+        self._templates_scroll.setWidget(content)
 
-        # Import button (classic style)
         import_btn = IOSPrimaryButton(QCoreApplication.translate("Nugget", "  Import Templates (.batter)"))
         import_btn.clicked.connect(self.show_add_templates_dialog)
         self.templates_import_btn = import_btn
         self.templates_layout.addWidget(import_btn)
 
         self.templates_placeholder = QLabel(QCoreApplication.translate("Nugget", "No templates added yet"))
-        self.templates_placeholder.setStyleSheet("font-size: 15px; color: #8E8E93;")
         self.templates_placeholder.setAlignment(Qt.AlignCenter)
         self.templates_layout.addWidget(self.templates_placeholder)
 
-        # Load existing templates using classic create_ui()
         self._load_templates_list()
 
-        return scroll
+        return self._templates_scroll
 
     def show_add_templates_dialog(self):
-        """Port of classic on_importTemplatesBtn_clicked"""
         from PySide6.QtWidgets import QFileDialog, QMessageBox
         selected_files, _ = QFileDialog.getOpenFileNames(
             self.window, QCoreApplication.translate("Nugget", "Select Nugget Template Files"), "", "Zip Files (*.batter)"
@@ -288,7 +366,6 @@ class IOSPosterboardPage(QWidget):
             self._load_templates_list()
 
     def _load_templates_list(self):
-        """Port of classic load_templates_list / load_pb_templates - uses template.create_ui()"""
         from src.tweaks.tweaks import tweaks, TweakID
         templates = tweaks[TweakID.Templates].templates
         if not templates:
@@ -296,130 +373,80 @@ class IOSPosterboardPage(QWidget):
             return
         self.templates_placeholder.hide()
 
-        # Clear existing template widgets (keep import button and placeholder)
         for i in reversed(range(self.templates_layout.count())):
             widget = self.templates_layout.itemAt(i).widget()
             if widget is not None and widget not in (self.templates_placeholder, self.templates_import_btn):
                 widget.deleteLater()
 
-        # Classic approach: call template.create_ui() for each template
-        # This creates the full UI with previews, pickers, bundle ID, etc.
         widgets = {}
         for template in templates:
             template.create_ui(self.window, tweaks[TweakID.Templates], widgets, self.templates_layout)
 
     def _create_video_tab(self) -> QWidget:
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setStyleSheet("background-color: #1e1e1e; border: none;")
+        c = ColorThemeManager.instance().colors
+        self._video_scroll = QScrollArea()
+        self._video_scroll.setWidgetResizable(True)
         content = QWidget()
-        scroll.setWidget(content)
+        self._video_scroll.setWidget(content)
 
         v_layout = QVBoxLayout(content)
         v_layout.setContentsMargins(16, 16, 16, 32)
         v_layout.setSpacing(16)
 
-        # Thumbnail
+        self._video_labels = []
+
         thumb_row = QHBoxLayout()
         thumb_label = QLabel(QCoreApplication.translate("Nugget", "Thumbnail"))
-        thumb_label.setStyleSheet("font-size: 15px; color: #FFFFFF; min-width: 100px;")
+        self._video_labels.append(thumb_label)
         self.thumb_btn = QPushButton(QCoreApplication.translate("Nugget", "Choose Freeze Frame (.HEIC)"))
         self.thumb_btn.setCursor(Qt.PointingHandCursor)
-        self.thumb_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #1C1C1E;
-                border-radius: 10px;
-                color: #007AFF;
-                font-size: 15px;
-                padding: 12px 24px;
-                border: none;
-            }
-            QPushButton:hover { background-color: #2C2C2E; }
-        """)
         self.thumb_btn.clicked.connect(self.on_choose_thumb_clicked)
         thumb_row.addWidget(thumb_label)
         thumb_row.addWidget(self.thumb_btn, 1)
         v_layout.addLayout(thumb_row)
 
-        # Video
         video_row = QHBoxLayout()
         video_label = QLabel(QCoreApplication.translate("Nugget", "Video"))
-        video_label.setStyleSheet("font-size: 15px; color: #FFFFFF; min-width: 100px;")
+        self._video_labels.append(video_label)
         self.video_btn = QPushButton(QCoreApplication.translate("Nugget", "Choose Video"))
         self.video_btn.setCursor(Qt.PointingHandCursor)
-        self.video_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #1C1C1E;
-                border-radius: 10px;
-                color: #007AFF;
-                font-size: 15px;
-                padding: 12px 24px;
-                border: none;
-            }
-            QPushButton:hover { background-color: #2C2C2E; }
-        """)
         self.video_btn.clicked.connect(self.on_choose_video_clicked)
         video_row.addWidget(video_label)
         video_row.addWidget(self.video_btn, 1)
         v_layout.addLayout(video_row)
 
-        # Options
         v_layout.addWidget(QLabel(QCoreApplication.translate("Nugget", "Options")))
         self.loop_chk = QCheckBox(QCoreApplication.translate("Nugget", "Loop (use CoreAnimation method)"))
-        self.loop_chk.setStyleSheet("color: #FFFFFF; font-size: 15px;")
         self.loop_chk.setChecked(tweaks[TweakID.PosterBoard].loop_video)
         self.loop_chk.toggled.connect(self.on_loop_toggled)
         v_layout.addWidget(self.loop_chk)
 
         self.reverse_chk = QCheckBox(QCoreApplication.translate("Nugget", "Reverse on Loop"))
-        self.reverse_chk.setStyleSheet("color: #FFFFFF; font-size: 15px;")
         self.reverse_chk.setChecked(tweaks[TweakID.PosterBoard].reverse_video)
         self.reverse_chk.toggled.connect(self.on_reverse_toggled)
         v_layout.addWidget(self.reverse_chk)
 
         self.foreground_chk = QCheckBox(QCoreApplication.translate("Nugget", "Make Foreground (hides clock)"))
-        self.foreground_chk.setStyleSheet("color: #FFFFFF; font-size: 15px;")
         self.foreground_chk.setChecked(tweaks[TweakID.PosterBoard].use_foreground)
         self.foreground_chk.toggled.connect(self.on_foreground_toggled)
         v_layout.addWidget(self.foreground_chk)
 
-        # Calculation mode
         calc_row = QHBoxLayout()
         calc_label = QLabel(QCoreApplication.translate("Nugget", "Calculation Mode"))
-        calc_label.setStyleSheet("font-size: 15px; color: #FFFFFF; min-width: 100px;")
+        self._video_labels.append(calc_label)
         self.calc_mode_drp = QComboBox()
         self.calc_mode_drp.addItem(QCoreApplication.translate("Nugget", "Linear"))
         self.calc_mode_drp.addItem(QCoreApplication.translate("Nugget", "Discrete"))
         self.calc_mode_drp.setCurrentIndex(0 if tweaks[TweakID.PosterBoard].calculationMode == 'linear' else 1)
         self.calc_mode_drp.activated.connect(self.on_calc_mode_selected)
-        self.calc_mode_drp.setStyleSheet("""
-            QComboBox {
-                background-color: #1C1C1E;
-                border: none;
-                border-radius: 10px;
-                color: #FFFFFF;
-                font-size: 14px;
-                padding: 8px 12px;
-            }
-            QComboBox::drop-down { border: none; width: 24px; }
-            QComboBox QAbstractItemView {
-                background-color: #2C2C2E;
-                border: 1px solid #3A3A3C;
-                border-radius: 10px;
-                color: #FFFFFF;
-                selection-background-color: #007AFF;
-            }
-        """)
         calc_row.addWidget(calc_label)
         calc_row.addWidget(self.calc_mode_drp, 1)
         v_layout.addLayout(calc_row)
 
-        # Export video loop
         export_btn = IOSPrimaryButton(QCoreApplication.translate("Nugget", "Export Video Loop (.tendies)"))
         export_btn.clicked.connect(self.on_export_video_clicked)
         v_layout.addWidget(export_btn)
 
-        # Discover wallpapers + help
         ext_row = QHBoxLayout()
         discover_btn = IOSPrimaryButton(QCoreApplication.translate("Nugget", "Discover Wallpapers"))
         discover_btn.clicked.connect(self.on_discover_wallpapers)
@@ -433,7 +460,7 @@ class IOSPosterboardPage(QWidget):
 
         self._update_video_labels()
 
-        return scroll
+        return self._video_scroll
 
     def _update_video_labels(self):
         pb = tweaks[TweakID.PosterBoard]
@@ -483,7 +510,6 @@ class IOSPosterboardPage(QWidget):
         tweaks[TweakID.PosterBoard].calculationMode = 'linear' if index == 0 else 'discrete'
 
     def on_export_video_clicked(self):
-        import os
         import uuid
         import subprocess
         from shutil import make_archive, rmtree
@@ -514,7 +540,6 @@ class IOSPosterboardPage(QWidget):
         self.open_wallpaper_downloader()
 
     def open_wallpaper_downloader(self):
-        """Open the in-app wallpaper downloader (Cowabunga + CaPlayground)."""
         from src.gui.dialogs.wallpaper_downloader import WallpaperDownloaderDialog
         dialog = WallpaperDownloaderDialog(self.window, self)
         dialog.exec()
@@ -536,12 +561,10 @@ class IOSPosterboardPage(QWidget):
             self.refresh_tendies()
 
     def refresh_tendies(self):
-        # stop preview downloads for the cards we are about to destroy
         for reply, *_ in self._tendie_preview_replies:
             reply.abort()
         self._tendie_preview_replies = []
 
-        # Clear existing grid except download and add cards
         keep = (self.add_tendies_card, self.download_card)
         for i in reversed(range(self.tendies_grid.count())):
             widget = self.tendies_grid.itemAt(i).widget()
@@ -550,7 +573,6 @@ class IOSPosterboardPage(QWidget):
 
         tendies = tweaks[TweakID.PosterBoard].tendies
         if not tendies:
-            # Ensure download card + add card are the only items
             self.tendies_grid.addWidget(self.download_card, 0, 0, 1, 2)
             self.tendies_grid.addWidget(self.add_tendies_card, 1, 0)
             return
@@ -565,10 +587,10 @@ class IOSPosterboardPage(QWidget):
                 col = 0
                 row += 1
 
-        # Add the add card at the end
         self.tendies_grid.addWidget(self.add_tendies_card, row, col)
 
     def _create_tendie_card(self, tendie) -> QWidget:
+        c = ColorThemeManager.instance().colors
         card = IOSCard()
         card.setFixedSize(140, 160)
         card.setCursor(Qt.PointingHandCursor)
@@ -578,7 +600,6 @@ class IOSPosterboardPage(QWidget):
         inner.setSpacing(8)
         inner.setAlignment(Qt.AlignTop)
 
-        # Icon from tendie
         icon = QLabel()
         icon.setFixedSize(80, 80)
         icon.setAlignment(Qt.AlignCenter)
@@ -588,23 +609,19 @@ class IOSPosterboardPage(QWidget):
             if not pixmap.isNull():
                 icon.setPixmap(pixmap.scaled(80, 80, Qt.KeepAspectRatio, Qt.SmoothTransformation))
             else:
-                icon.setStyleSheet("background-color: #2C2C2E; border-radius: 10px;")
+                icon.setStyleSheet(f"background-color: {c.surface_hover}; border-radius: 10px;")
         except Exception:
-            icon.setStyleSheet("background-color: #2C2C2E; border-radius: 10px;")
+            icon.setStyleSheet(f"background-color: {c.surface_hover}; border-radius: 10px;")
         inner.addWidget(icon, 0, Qt.AlignCenter)
 
-        # Load real preview image by matching the tendie's name against the
-        # cached wallpaper catalogs (falls back to the generic icon above).
         self._load_tendie_preview_by_name(card, icon, tendie.name)
 
-        # Name
         name = QLabel(tendie.name.replace(".tendies", ""))
-        name.setStyleSheet("font-size: 13px; color: #8E8E93; text-align: center;")
+        name.setStyleSheet(f"font-size: 13px; color: {c.text_secondary}; text-align: center;")
         name.setAlignment(Qt.AlignCenter)
         name.setWordWrap(True)
         inner.addWidget(name)
 
-        # Preview + Delete buttons side by side
         actions = QHBoxLayout()
         actions.setSpacing(6)
         actions.setContentsMargins(0, 0, 0, 0)
@@ -616,9 +633,9 @@ class IOSPosterboardPage(QWidget):
             "Nugget", "Lock screen preview"))
         preview_btn.setCursor(Qt.PointingHandCursor)
         preview_btn.setStyleSheet(
-            "QToolButton { background-color: #1C1C1E; color: #0A84FF; "
-            "border: 1px solid #3A3A3C; border-radius: 12px; padding: 7px; }"
-            "QToolButton:hover { background-color: #48484A; }"
+            f"QToolButton {{ background-color: {c.bg_secondary}; color: {c.accent}; "
+            f"border: 1px solid {c.border}; border-radius: 12px; padding: 7px; }}"
+            f"QToolButton:hover {{ background-color: {c.scrollbar_pressed}; }}"
         )
         preview_btn.clicked.connect(
             lambda: self._show_tendie_preview(tendie))
@@ -629,9 +646,9 @@ class IOSPosterboardPage(QWidget):
         from PySide6.QtGui import QIcon as _QIcon
         del_btn.setIcon(_QIcon(":/icon/trash.svg"))
         del_btn.setStyleSheet(
-            "QToolButton { background-color: #1C1C1E; color: #FF3B30; "
-            "border: 1px solid #3A3A3C; border-radius: 12px; padding: 7px; }"
-            "QToolButton:hover { background-color: #FF3B30; color: white; }"
+            f"QToolButton {{ background-color: {c.bg_secondary}; color: {c.error}; "
+            f"border: 1px solid {c.border}; border-radius: 12px; padding: 7px; }}"
+            f"QToolButton:hover {{ background-color: {c.error}; color: {c.text_inverse}; }}"
         )
         del_btn.setCursor(Qt.PointingHandCursor)
         del_btn.clicked.connect(lambda: self._delete_tendie(tendie))
@@ -643,8 +660,6 @@ class IOSPosterboardPage(QWidget):
     def _show_tendie_preview(self, tendie):
         from src.gui.dialogs.tendie_preview_dialog import TendiePreviewDialog
         TendiePreviewDialog(tendie, self).exec()
-
-    # --- tendie preview by name ---
 
     def _load_tendie_preview_by_name(self, card, icon_lbl, file_name):
         try:
@@ -691,7 +706,6 @@ class IOSPosterboardPage(QWidget):
             pixmap = QPixmap.fromImage(image) if not image.isNull() else QPixmap(path)
             if pixmap.isNull():
                 return
-            # square cover: expand to fill 80x80, then center-crop
             scaled = pixmap.scaled(
                 80, 80, Qt.KeepAspectRatioByExpanding, Qt.SmoothTransformation)
             x = (scaled.width() - 80) // 2
@@ -714,12 +728,7 @@ class IOSPosterboardPage(QWidget):
         self.refresh_tendies()
 
     def _reset_posterboard(self):
-        """Show dialog to schedule a PosterBoard reset.
-
-        Reuses the existing reset mechanism (tweaks[PosterBoard].resetModes)
-        that the classic UI's Reset dropdown drives — this only adds the
-        iOS-style dialog, it does not duplicate the reset logic itself.
-        """
+        c = ColorThemeManager.instance().colors
         from PySide6.QtWidgets import (
             QDialog, QVBoxLayout, QLabel, QCheckBox, QDialogButtonBox, QMessageBox,
         )
@@ -727,22 +736,22 @@ class IOSPosterboardPage(QWidget):
         dialog = QDialog(self.window)
         dialog.setWindowTitle(QCoreApplication.translate("Nugget", "Reset PosterBoard"))
         dialog.setMinimumWidth(350)
-        dialog.setStyleSheet("""
-            QDialog { background-color: #1e1e1e; }
-            QLabel { color: #FFFFFF; font-size: 15px; }
-            QCheckBox { color: #FFFFFF; font-size: 14px; spacing: 8px; }
-            QCheckBox::indicator { width: 20px; height: 20px; }
-            QDialogButtonBox QPushButton {
-                background-color: #007AFF;
+        dialog.setStyleSheet(f"""
+            QDialog {{ background-color: {c.bg_primary}; }}
+            QLabel {{ color: {c.text_primary}; font-size: 15px; }}
+            QCheckBox {{ color: {c.text_primary}; font-size: 14px; spacing: 8px; }}
+            QCheckBox::indicator {{ width: 20px; height: 20px; }}
+            QDialogButtonBox QPushButton {{
+                background-color: {c.accent};
                 border-radius: 10px;
-                color: #FFFFFF;
+                color: {c.text_primary};
                 font-size: 14px;
                 font-weight: 600;
                 padding: 10px 20px;
                 border: none;
                 min-width: 80px;
-            }
-            QDialogButtonBox QPushButton:hover { background-color: #0056CC; }
+            }}
+            QDialogButtonBox QPushButton:hover {{ background-color: {c.accent_hover}; }}
         """)
 
         layout = QVBoxLayout(dialog)
@@ -755,7 +764,7 @@ class IOSPosterboardPage(QWidget):
             "strangely or the database is corrupted (malformed) after a restore."
         ))
         desc.setWordWrap(True)
-        desc.setStyleSheet("color: #8E8E93; font-size: 13px;")
+        desc.setStyleSheet(f"color: {c.text_secondary}; font-size: 13px;")
         layout.addWidget(desc)
 
         reset_collections = QCheckBox(QCoreApplication.translate("Nugget", "Collections"))

--- a/src/gui/ios/settings.py
+++ b/src/gui/ios/settings.py
@@ -16,6 +16,7 @@ from src.controllers.preset_manager import PresetManager
 from src.controllers.hotload import HotLoad, confirm_flagged
 from src.tweaks.tweaks import tweaks, TweakID
 from src.gui.thread_workers.apply_worker import ResetPairingThread
+from src.gui.theme import ColorThemeManager, AccentPicker
 
 
 class IOSSettingsPage(QWidget):
@@ -25,26 +26,42 @@ class IOSSettingsPage(QWidget):
         self.setObjectName("iosContainer")
         self.lang_indexes = []
         self.preset_manager = PresetManager()
+        self._tm = ColorThemeManager.instance()
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
-
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setStyleSheet("background-color: #1e1e1e; border: none;")
-        self.scroll_area = scroll
+        self._scroll = QScrollArea()
+        self._scroll.setWidgetResizable(True)
+        self.scroll_area = self._scroll
         content = QWidget()
-        scroll.setWidget(content)
-        layout.addWidget(scroll)
+        self._scroll.setWidget(content)
+        layout.addWidget(self._scroll)
 
         self.content_layout = QVBoxLayout(content)
         self.content_layout.setContentsMargins(16, 16, 16, 32)
         self.content_layout.setSpacing(8)
 
-        # Appearance
+        # --- Appearance ---
         self.content_layout.addWidget(IOSSectionHeader(QCoreApplication.translate("Nugget", "Appearance")))
+
+        dark_on = self._tm.is_dark
+        self._appearance_switch = self._make_switch(
+            QCoreApplication.translate("Nugget", "Dark Mode"),
+            dark_on,
+            lambda on: self._tm.set_mode("dark" if on else "light"),
+        )
+
+        accent_row_card = QWidget()
+        accent_row = QHBoxLayout(accent_row_card)
+        accent_row.setContentsMargins(16, 10, 16, 10)
+        accent_row.setSpacing(12)
+        accent_label = QLabel(QCoreApplication.translate("Nugget", "Accent Color"))
+        accent_row.addWidget(accent_label, 1)
+        self._accent_picker = AccentPicker()
+        accent_row.addWidget(self._accent_picker)
+        self.content_layout.addWidget(accent_row_card)
 
         theme_on = self.window.theme_manager.current_theme == ThemeManager.IOS
         self.theme_switch = self._make_switch(
@@ -159,16 +176,104 @@ class IOSSettingsPage(QWidget):
         self.refresh_presets()
         self.content_layout.addStretch()
 
+        self._retheme()
+        self._tm.theme_changed.connect(self._retheme)
+
+    def _retheme(self):
+        c = self._tm.colors
+        self._scroll.setStyleSheet(
+            f"background-color: {c.bg_primary}; border: none;"
+        )
+        self._accent_picker.setStyleSheet(
+            f"background-color: {c.bg_primary};"
+        )
+        if hasattr(self, '_lang_drp'):
+            self._retheme_lang_dropdown()
+        if hasattr(self, '_saved_ids_list'):
+            self._retheme_saved_ids_list()
+        if hasattr(self, '_preset_name_txt'):
+            self._retheme_preset_inputs()
+        if hasattr(self, '_preset_list'):
+            self._retheme_preset_list()
+
+    def _retheme_lang_dropdown(self):
+        c = self._tm.colors
+        self._lang_drp.setStyleSheet(f"""
+            QComboBox {{
+                background-color: {c.bg_input};
+                border: none;
+                border-radius: 10px;
+                color: {c.text_primary};
+                font-size: 14px;
+                padding: 8px 12px;
+                min-width: 140px;
+            }}
+            QComboBox::drop-down {{ border: none; width: 24px; }}
+            QComboBox::down-arrow {{ image: none; border-left: 5px solid transparent; border-right: 5px solid transparent; border-top: 6px solid {c.text_secondary}; margin-right: 10px; }}
+            QComboBox QAbstractItemView {{
+                background-color: {c.bg_tertiary};
+                border: 1px solid {c.border};
+                border-radius: 10px;
+                color: {c.text_primary};
+                selection-background-color: {c.accent};
+            }}
+        """)
+
+    def _retheme_saved_ids_list(self):
+        c = self._tm.colors
+        self._saved_ids_list.setStyleSheet(f"""
+            QListWidget {{
+                background-color: {c.bg_input};
+                border: none;
+                border-radius: 8px;
+                color: {c.text_primary};
+                font-size: 13px;
+                padding: 4px;
+            }}
+            QListWidget::item {{ padding: 6px; }}
+            QListWidget::item:selected {{ background-color: {c.scrollbar_pressed}; color: {c.text_primary}; }}
+        """)
+
+    def _retheme_preset_inputs(self):
+        c = self._tm.colors
+        for edit in (self._preset_name_txt, self._preset_desc_txt):
+            edit.setStyleSheet(f"""
+                QLineEdit {{
+                    background-color: {c.bg_input};
+                    border: none;
+                    border-radius: 10px;
+                    color: {c.text_primary};
+                    font-size: 14px;
+                    padding: 10px 14px;
+                }}
+            """)
+
+    def _retheme_preset_list(self):
+        c = self._tm.colors
+        self._preset_list.setStyleSheet(f"""
+            QListWidget {{
+                background-color: {c.bg_input};
+                border: none;
+                border-radius: 8px;
+                color: {c.text_primary};
+                font-size: 13px;
+                padding: 4px;
+            }}
+            QListWidget::item {{ padding: 8px; }}
+            QListWidget::item:selected {{ background-color: {c.scrollbar_pressed}; color: {c.text_primary}; }}
+        """)
+
     # ---------- helpers ----------
 
     def _make_switch(self, title: str, checked: bool, on_toggled) -> IOSSwitch:
+        c = self._tm.colors
         card = QWidget()
         row = QHBoxLayout(card)
         row.setContentsMargins(16, 10, 16, 10)
         row.setSpacing(12)
 
         label = QLabel(title)
-        label.setStyleSheet("color: #FFFFFF; font-size: 15px;")
+        label.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
         label.setWordWrap(True)
         row.addWidget(label, 1)
 
@@ -264,21 +369,22 @@ class IOSSettingsPage(QWidget):
         self.window._sync_settings()
 
     def _make_text_row(self, title: str, current: str, on_submit):
+        c = self._tm.colors
         card = QWidget()
         row = QHBoxLayout(card)
         row.setContentsMargins(16, 10, 16, 10)
         row.setSpacing(12)
 
         label = QLabel(title)
-        label.setStyleSheet("color: #FFFFFF; font-size: 15px;")
+        label.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
         row.addWidget(label, 1)
 
         self.org_value_lbl = QLabel(current if current else QCoreApplication.translate("MainWindow", "None"))
-        self.org_value_lbl.setStyleSheet("color: #8E8E93; font-size: 14px;")
+        self.org_value_lbl.setStyleSheet(f"color: {c.text_secondary}; font-size: 14px;")
         row.addWidget(self.org_value_lbl)
 
-        edit_btn = QLabel("✎")
-        edit_btn.setStyleSheet("color: #007AFF; font-size: 17px;")
+        edit_btn = QLabel("\u270e")
+        edit_btn.setStyleSheet(f"color: {c.accent}; font-size: 17px;")
         edit_btn.setCursor(Qt.PointingHandCursor)
         edit_btn.mousePressEvent = lambda e: self._on_text_row_edit(title, on_submit)
         row.addWidget(edit_btn)
@@ -286,30 +392,31 @@ class IOSSettingsPage(QWidget):
         self.content_layout.addWidget(card)
 
     def _on_text_row_edit(self, title: str, on_submit):
+        c = self._tm.colors
         dialog = QInputDialog(self)
         dialog.setWindowTitle(title)
         dialog.setLabelText(QCoreApplication.translate("Nugget", "Enter value:"))
         dialog.setTextValue(self.window.device_manager.pref_manager.organization_name)
-        dialog.setStyleSheet("""
-            QDialog, QInputDialog { background-color: #1e1e1e; }
-            QLabel { color: #FFFFFF; font-size: 15px; }
-            QLineEdit {
-                background-color: #1C1C1E;
+        dialog.setStyleSheet(f"""
+            QDialog, QInputDialog {{ background-color: {c.bg_primary}; }}
+            QLabel {{ color: {c.text_primary}; font-size: 15px; }}
+            QLineEdit {{
+                background-color: {c.bg_input};
                 border: none;
                 border-radius: 10px;
-                color: #FFFFFF;
+                color: {c.text_primary};
                 font-size: 15px;
                 padding: 10px 14px;
-            }
-            QPushButton {
-                background-color: #007AFF;
+            }}
+            QPushButton {{
+                background-color: {c.accent};
                 border-radius: 10px;
-                color: #FFFFFF;
+                color: {c.text_primary};
                 font-size: 15px;
                 font-weight: 600;
                 padding: 10px 20px;
                 border: none;
-            }
+            }}
         """)
         if dialog.exec() == QDialog.Accepted:
             text = dialog.textValue()
@@ -323,36 +430,18 @@ class IOSSettingsPage(QWidget):
         self.window._sync_settings()
 
     def _make_language_row(self):
+        c = self._tm.colors
         card = QWidget()
         row = QHBoxLayout(card)
         row.setContentsMargins(16, 10, 16, 10)
         row.setSpacing(12)
 
         label = QLabel(QCoreApplication.translate("Nugget", "App Language"))
-        label.setStyleSheet("color: #FFFFFF; font-size: 15px;")
+        label.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
         row.addWidget(label, 1)
 
         self.lang_drp = QComboBox()
-        self.lang_drp.setStyleSheet("""
-            QComboBox {
-                background-color: #1C1C1E;
-                border: none;
-                border-radius: 10px;
-                color: #FFFFFF;
-                font-size: 14px;
-                padding: 8px 12px;
-                min-width: 140px;
-            }
-            QComboBox::drop-down { border: none; width: 24px; }
-            QComboBox::down-arrow { image: none; border-left: 5px solid transparent; border-right: 5px solid transparent; border-top: 6px solid #8E8E93; margin-right: 10px; }
-            QComboBox QAbstractItemView {
-                background-color: #2C2C2E;
-                border: 1px solid #3A3A3C;
-                border-radius: 10px;
-                color: #FFFFFF;
-                selection-background-color: #007AFF;
-            }
-        """)
+        self._lang_drp = self.lang_drp
         for language in available_languages.keys():
             self.lang_indexes.append(available_languages[language])
             self.lang_drp.addItem(language)
@@ -372,12 +461,10 @@ class IOSSettingsPage(QWidget):
             self.window.translator.set_new_language(new_lang, restart=True)
 
     def _make_pb_setup_section(self):
+        c = self._tm.colors
         self.content_layout.addWidget(IOSSectionHeader(
             QCoreApplication.translate("Nugget", "PosterBoard Database")
         ))
-
-        # wallpapers are always applied as configurations (iOS 26+ data store
-        # layout); the descriptors apply method is broken and was removed
 
         self._make_label_row(QCoreApplication.translate("Nugget", "Database"), "sqlite: None")
 
@@ -390,29 +477,16 @@ class IOSSettingsPage(QWidget):
             self._on_pb_select_db,
         )
 
-        # saved ids list
         ids_card = QWidget()
         ids_layout = QVBoxLayout(ids_card)
         ids_layout.setContentsMargins(16, 12, 16, 12)
         ids_layout.setSpacing(8)
         ids_title = QLabel(QCoreApplication.translate("Nugget", "Saved Configuration IDs"))
-        ids_title.setStyleSheet("color: #FFFFFF; font-size: 15px;")
+        ids_title.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
         ids_layout.addWidget(ids_title)
 
         self.saved_ids_list = QListWidget()
-        self.saved_ids_list.setStyleSheet("""
-            QListWidget {
-                background-color: #1C1C1E;
-                border: none;
-                border-radius: 8px;
-                color: #e8e8e8;
-                font-size: 13px;
-                padding: 4px;
-            }
-            QListWidget::item { padding: 6px; }
-            QListWidget::item:selected { background-color: #535353; color: #ffffff; }
-        """)
-        self.saved_ids_list.setMinimumHeight(90)
+        self._saved_ids_list = self.saved_ids_list
         ids_layout.addWidget(self.saved_ids_list)
 
         ids_btns = QHBoxLayout()
@@ -428,17 +502,18 @@ class IOSSettingsPage(QWidget):
         self._refresh_saved_ids()
 
     def _make_label_row(self, title: str, value: str):
+        c = self._tm.colors
         card = QWidget()
         row = QHBoxLayout(card)
         row.setContentsMargins(16, 10, 16, 10)
         row.setSpacing(12)
 
         label = QLabel(title)
-        label.setStyleSheet("color: #FFFFFF; font-size: 15px;")
+        label.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
         row.addWidget(label, 1)
 
         self.pb_db_lbl = QLabel(value)
-        self.pb_db_lbl.setStyleSheet("color: #8E8E93; font-size: 14px;")
+        self.pb_db_lbl.setStyleSheet(f"color: {c.text_secondary}; font-size: 14px;")
         row.addWidget(self.pb_db_lbl)
         self.content_layout.addWidget(card)
 
@@ -450,18 +525,19 @@ class IOSSettingsPage(QWidget):
 
     def _make_mini_button(self, title: str):
         from PySide6.QtWidgets import QPushButton
+        c = self._tm.colors
         btn = QPushButton(title)
         btn.setCursor(Qt.PointingHandCursor)
-        btn.setStyleSheet("""
-            QPushButton {
-                background-color: #3b3b3b;
+        btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {c.scrollbar};
                 border: none;
                 border-radius: 10px;
-                color: #FFFFFF;
+                color: {c.text_primary};
                 font-size: 13px;
                 padding: 8px 12px;
-            }
-            QPushButton:hover { background-color: #4a4a4a; }
+            }}
+            QPushButton:hover {{ background-color: {c.surface_hover}; }}
         """)
         return btn
 
@@ -521,6 +597,7 @@ class IOSSettingsPage(QWidget):
     # ---------- presets ----------
 
     def _make_presets_section(self):
+        c = self._tm.colors
         self.content_layout.addWidget(IOSSectionHeader(
             QCoreApplication.translate("Nugget", "Presets")
         ))
@@ -532,20 +609,11 @@ class IOSSettingsPage(QWidget):
 
         name_row = QHBoxLayout()
         self.preset_name_txt = QLineEdit()
+        self._preset_name_txt = self.preset_name_txt
         self.preset_name_txt.setPlaceholderText(QCoreApplication.translate("Nugget", "Preset name"))
         self.preset_desc_txt = QLineEdit()
+        self._preset_desc_txt = self.preset_desc_txt
         self.preset_desc_txt.setPlaceholderText(QCoreApplication.translate("Nugget", "Description (optional)"))
-        for edit in (self.preset_name_txt, self.preset_desc_txt):
-            edit.setStyleSheet("""
-                QLineEdit {
-                    background-color: #1C1C1E;
-                    border: none;
-                    border-radius: 10px;
-                    color: #FFFFFF;
-                    font-size: 14px;
-                    padding: 10px 14px;
-                }
-            """)
         name_row.addWidget(self.preset_name_txt, 2)
         name_row.addWidget(self.preset_desc_txt, 3)
         presets_layout.addLayout(name_row)
@@ -555,18 +623,7 @@ class IOSSettingsPage(QWidget):
         presets_layout.addWidget(save_btn)
 
         self.preset_list = QListWidget()
-        self.preset_list.setStyleSheet("""
-            QListWidget {
-                background-color: #1C1C1E;
-                border: none;
-                border-radius: 8px;
-                color: #e8e8e8;
-                font-size: 13px;
-                padding: 4px;
-            }
-            QListWidget::item { padding: 8px; }
-            QListWidget::item:selected { background-color: #535353; color: #ffffff; }
-        """)
+        self._preset_list = self.preset_list
         self.preset_list.setMinimumHeight(120)
         presets_layout.addWidget(self.preset_list)
 
@@ -587,7 +644,6 @@ class IOSSettingsPage(QWidget):
         self.content_layout.addWidget(card)
 
     def scroll_to_presets(self):
-        """Scroll the settings page to the presets section at the bottom."""
         if self.scroll_area is not None:
             QTimer.singleShot(0, self._scroll_to_bottom)
 
@@ -605,9 +661,9 @@ class IOSSettingsPage(QWidget):
             tags = meta.get("tags", [])
             tag_str = "  #" + " #".join(tags) if tags else ""
             if desc:
-                item_text = f"{name}\n  {desc}  ({model} • iOS {ios}){tag_str}"
+                item_text = f"{name}\n  {desc}  ({model} \u2022 iOS {ios}){tag_str}"
             else:
-                item_text = f"{name}  ({model} • iOS {ios}){tag_str}"
+                item_text = f"{name}  ({model} \u2022 iOS {ios}){tag_str}"
             item = QListWidgetItem(item_text)
             self.preset_list.addItem(item)
             item.setData(Qt.UserRole, name)
@@ -648,12 +704,10 @@ class IOSSettingsPage(QWidget):
             self, QCoreApplication.translate("Nugget", "Load Preset"),
             QCoreApplication.translate(
                 "Nugget",
-                "Load preset \"{0}\"?\n\nDescription: {1}\nDevice: {2} • iOS {3}\n\nThis will replace your current configuration."
+                "Load preset \"{0}\"?\n\nDescription: {1}\nDevice: {2} \u2022 iOS {3}\n\nThis will replace your current configuration."
             ).format(name, desc, model, ios))
         if confirm != QMessageBox.StandardButton.Yes:
             return
-        # HotLoad: never let a preset resurrect a feature that is hidden on this
-        # device — those tweaks are stripped during load, so warn what's skipped.
         dm = self.window.device_manager
         hotload = HotLoad(getattr(self.window, "settings", None))
         hidden_feats = self.preset_manager.preset_hidden_feature_names(
@@ -666,9 +720,9 @@ class IOSSettingsPage(QWidget):
                 QCoreApplication.translate(
                     "Nugget",
                     "This preset contains features that are currently hidden by "
-                    "the safety rules for this device:\n\n• {0}\n\n"
+                    "the safety rules for this device:\n\n\u2022 {0}\n\n"
                     "They will NOT be loaded, so applying may not match the "
-                    "preset's intended state.").format("\n• ".join(hidden_feats)))
+                    "preset's intended state.").format("\n\u2022 ".join(hidden_feats)))
         compat_msg = self._daemon_compat_warning(name, meta)
         if compat_msg:
             reply = QMessageBox.warning(
@@ -700,7 +754,6 @@ class IOSSettingsPage(QWidget):
 
     @staticmethod
     def _major_version(ver: str):
-        """Return the iOS major version as an int, or None if not parseable."""
         try:
             return int(str(ver).split(".")[0])
         except (ValueError, TypeError, IndexError):
@@ -716,9 +769,6 @@ class IOSSettingsPage(QWidget):
         return ""
 
     def _daemon_compat_warning(self, name: str, meta) -> Optional[str]:
-        """Return a warning string when the preset's daemon changes were saved
-        for a different iOS major version or device type than the one in use;
-        None when the preset has no daemon changes or we cannot tell."""
         if not self.preset_manager.preset_has_daemon_changes(name):
             return None
         cur_ver = self.window.device_manager.get_current_device_version() or ""
@@ -740,7 +790,7 @@ class IOSSettingsPage(QWidget):
         return (
             "This preset contains daemon modifications that were saved for a "
             "different device:\n\n"
-            + "\n".join("• " + m for m in mismatches)
+            + "\n".join("\u2022 " + m for m in mismatches)
             + "\n\nDaemons are sensitive to the iOS version and device type, and "
               "applying incompatible ones can bootloop your device. "
               "Proceed with caution."
@@ -853,4 +903,3 @@ class IOSSettingsPage(QWidget):
         from src.gui.dialogs import AboutProgramDialog
         dialog = AboutProgramDialog(self.window)
         dialog.exec()
-

--- a/src/gui/ios/statusbar.py
+++ b/src/gui/ios/statusbar.py
@@ -1,13 +1,14 @@
 from PySide6.QtCore import Qt, QCoreApplication
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QScrollArea, QHBoxLayout, QLabel,
-    QDialog
+    QDialog, QPushButton
 )
 
 from src.gui.ios.components import (
     IOSSectionHeader, IOSSwitch, IOSSettingsRow,
     TextInputDialog, NumberInputDialog
 )
+from src.gui.theme import ColorThemeManager
 from src.tweaks.tweaks import tweaks, TweakID
 from src.tweaks.status_bar.status_setter import StatusBarItem
 
@@ -26,7 +27,7 @@ class IOSStatusBarPage(QWidget):
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
-        scroll.setStyleSheet("background-color: #1e1e1e; border: none;")
+        self._scroll = scroll
         content = QWidget()
         scroll.setWidget(content)
         layout.addWidget(scroll)
@@ -188,6 +189,49 @@ class IOSStatusBarPage(QWidget):
 
         self.content_layout.addStretch()
 
+        self._retheme()
+        ColorThemeManager.instance().theme_changed.connect(self._retheme)
+
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        self._scroll.setStyleSheet(f"background-color: {c.bg_primary}; border: none;")
+        for i in range(self.content_layout.count()):
+            item = self.content_layout.itemAt(i)
+            if item is None:
+                continue
+            widget = item.widget()
+            if widget is None:
+                continue
+            # Style labels inside cards (switch rows, text rows, number rows)
+            row = widget.findChild(QHBoxLayout)
+            if row is not None:
+                for j in range(row.count()):
+                    child = row.itemAt(j)
+                    if child is None:
+                        continue
+                    w = child.widget()
+                    if w is None:
+                        continue
+                    if isinstance(w, QLabel):
+                        current = w.styleSheet()
+                        if "font-size: 15px" in current:
+                            w.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
+                        elif "font-size: 14px" in current:
+                            w.setStyleSheet(f"color: {c.text_secondary}; font-size: 14px;")
+                        elif "font-size: 17px" in current:
+                            w.setStyleSheet(f"color: {c.accent}; font-size: 17px;")
+            # Style QPushButton (edit buttons) inside cards
+            btn = widget.findChild(QPushButton) if hasattr(widget, 'findChild') else None
+            if btn is not None:
+                btn.setStyleSheet(f"""
+                    QPushButton {{
+                        background-color: transparent;
+                        border: none;
+                        color: {c.accent};
+                        font-size: 17px;
+                    }}
+                """)
+
     def _make_item_handler(self, item: StatusBarItem):
         def handler(checked: bool):
             if checked:
@@ -200,12 +244,13 @@ class IOSStatusBarPage(QWidget):
         return handler
 
     def _make_switch(self, title: str, checked: bool, on_toggled):
+        c = ColorThemeManager.instance().colors
         card = QWidget()
         row = QHBoxLayout(card)
         row.setContentsMargins(16, 10, 16, 10)
         row.setSpacing(12)
         label = QLabel(title)
-        label.setStyleSheet("color: #FFFFFF; font-size: 15px;")
+        label.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
         row.addWidget(label, 1)
         switch = IOSSwitch(checked)
         switch.toggled.connect(on_toggled)
@@ -214,17 +259,18 @@ class IOSStatusBarPage(QWidget):
         return switch
 
     def _make_text_row(self, title: str, overridden: bool, current: str, setter, unsetter):
+        c = ColorThemeManager.instance().colors
         card = QWidget()
         row = QHBoxLayout(card)
         row.setContentsMargins(16, 10, 16, 10)
         row.setSpacing(12)
 
         label = QLabel(title)
-        label.setStyleSheet("color: #FFFFFF; font-size: 15px;")
+        label.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
         row.addWidget(label, 1)
 
         value_lbl = QLabel(current if overridden else QCoreApplication.translate("Nugget", "Default"))
-        value_lbl.setStyleSheet("color: #8E8E93; font-size: 14px;")
+        value_lbl.setStyleSheet(f"color: {c.text_secondary}; font-size: 14px;")
         row.addWidget(value_lbl)
 
         switch = IOSSwitch(overridden)
@@ -234,13 +280,13 @@ class IOSStatusBarPage(QWidget):
         edit_btn = IOSSettingsRow("")
         edit_btn.setFixedWidth(44)
         edit_btn.setText("✎")
-        edit_btn.setStyleSheet("""
-            QPushButton {
+        edit_btn.setStyleSheet(f"""
+            QPushButton {{
                 background-color: transparent;
                 border: none;
-                color: #007AFF;
+                color: {c.accent};
                 font-size: 17px;
-            }
+            }}
         """)
         edit_btn.clicked.connect(lambda: self._on_text_row_edit(title, current, setter, label, value_lbl))
         row.addWidget(edit_btn)
@@ -264,17 +310,18 @@ class IOSStatusBarPage(QWidget):
             label.setText(title)
 
     def _make_number_row(self, title: str, overridden: bool, current: int, setter, unsetter, min_val: int, max_val: int):
+        c = ColorThemeManager.instance().colors
         card = QWidget()
         row = QHBoxLayout(card)
         row.setContentsMargins(16, 10, 16, 10)
         row.setSpacing(12)
 
         label = QLabel(title)
-        label.setStyleSheet("color: #FFFFFF; font-size: 15px;")
+        label.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
         row.addWidget(label, 1)
 
         value_lbl = QLabel(str(current) if overridden else QCoreApplication.translate("Nugget", "Default"))
-        value_lbl.setStyleSheet("color: #8E8E93; font-size: 14px;")
+        value_lbl.setStyleSheet(f"color: {c.text_secondary}; font-size: 14px;")
         row.addWidget(value_lbl)
 
         switch = IOSSwitch(overridden)
@@ -282,7 +329,7 @@ class IOSStatusBarPage(QWidget):
         row.addWidget(switch)
 
         edit_btn = QLabel("✎")
-        edit_btn.setStyleSheet("color: #007AFF; font-size: 17px;")
+        edit_btn.setStyleSheet(f"color: {c.accent}; font-size: 17px;")
         edit_btn.setCursor(Qt.PointingHandCursor)
         edit_btn.mousePressEvent = lambda e: self._on_number_row_edit(title, current, setter, value_lbl, min_val, max_val)
         row.addWidget(edit_btn)

--- a/src/gui/ios/tweaks.py
+++ b/src/gui/ios/tweaks.py
@@ -8,6 +8,7 @@ from src.gui.ios.components import (
     IOSSwitch, TextInputDialog, NumberInputDialog
 )
 from src.gui.ios.compat import is_tweak_compatible
+from src.gui.theme import ColorThemeManager
 from src.tweaks.tweaks import tweaks, TweakID
 from src.tweaks.registry import SPECS_BY_SECTION, SECTION_FEATURES, Kind, Section
 from src.tweaks.tweak_loader import load_plist_tweaks
@@ -66,6 +67,7 @@ class IOSSectionContent(QWidget):
         super().__init__(parent)
         self.window = window
         self.sections = sections
+        self._switch_labels = []
 
         # Load tweaks (idempotent) so the sections below actually populate
         load_plist_tweaks()
@@ -103,8 +105,10 @@ class IOSSectionContent(QWidget):
             row_layout.setContentsMargins(0, 0, 0, 0)
             row_layout.setSpacing(12)
 
+            c = ColorThemeManager.instance().colors
             label = QLabel(title)
-            label.setStyleSheet("color: #FFFFFF; font-size: 15px;")
+            label.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
+            self._switch_labels.append(label)
             row_layout.addWidget(label, 1)
 
             switch = IOSSwitch(tweak.enabled)
@@ -197,6 +201,11 @@ class IOSSectionContent(QWidget):
         if self.force_solarium_fallback_card is not None:
             self.force_solarium_fallback_card.setVisible(visible)
 
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        for lbl in self._switch_labels:
+            lbl.setStyleSheet(f"color: {c.text_primary}; font-size: 15px;")
+
     def _show_text_input_dialog(self, tweak_id: TweakID, title: str, current: str, row: IOSSettingsRow):
         dialog = TextInputDialog(title, current, self)
         if dialog.exec() == QDialog.Accepted:
@@ -225,10 +234,18 @@ class IOSTweaksPage(QWidget):
 
         scroll = QScrollArea(self)
         scroll.setWidgetResizable(True)
-        scroll.setStyleSheet("background-color: #1e1e1e; border: none;")
+        self._scroll = scroll
         self.content = IOSSectionContent(window, list(Section), self)
         scroll.setWidget(self.content)
         layout.addWidget(scroll)
+
+        self._retheme()
+        ColorThemeManager.instance().theme_changed.connect(self._retheme)
+
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        self._scroll.setStyleSheet(f"background-color: {c.bg_primary}; border: none;")
+        self.content._retheme()
 
     def set_force_solarium_fallback_visible(self, visible: bool):
         self.content.set_force_solarium_fallback_visible(visible)
@@ -249,10 +266,18 @@ class IOSSectionPage(QWidget):
 
         scroll = QScrollArea(self)
         scroll.setWidgetResizable(True)
-        scroll.setStyleSheet("background-color: #1e1e1e; border: none;")
+        self._scroll = scroll
         self.content = IOSSectionContent(window, [section], self)
         scroll.setWidget(self.content)
         layout.addWidget(scroll)
+
+        self._retheme()
+        ColorThemeManager.instance().theme_changed.connect(self._retheme)
+
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        self._scroll.setStyleSheet(f"background-color: {c.bg_primary}; border: none;")
+        self.content._retheme()
 
     def set_force_solarium_fallback_visible(self, visible: bool):
         self.content.set_force_solarium_fallback_visible(visible)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -21,12 +21,51 @@ from src.gui.ios.settings import IOSSettingsPage
 from src.gui.ios.statusbar import IOSStatusBarPage
 from src.tweaks.registry import Section
 
+from src.gui.theme import ColorThemeManager, t, theme_icon, themed_stylesheet
+
 from src.gui.main_window_mixins import (
     ApplyMixin,
     DeviceBarMixin,
     NavigationMixin,
     SettingsMixin,
 )
+
+# Classic chrome (device bar + sidebar + home toolbar) uses monochrome white
+# bootstrap SVGs; they must be recolored on every theme change.
+_CLASSIC_THEMED_ICONS = {
+    "phoneIconBtn": ":/icon/phone.svg",
+    "refreshBtn": ":/icon/arrow-clockwise.svg",
+    "homePageBtn": ":/icon/house.svg",
+    "gestaltPageBtn": ":/icon/iphone-island.svg",
+    "euEnablerPageBtn": ":/icon/geo-alt.svg",
+    "statusBarPageBtn": ":/icon/wifi.svg",
+    "passcodePageBtn": ":/icon/lock.svg",
+    "springboardOptionsPageBtn": ":/icon/app-indicator.svg",
+    "internalOptionsPageBtn": ":/icon/hdd.svg",
+    "liquidGlassPageBtn": ":/icon/liquid-glass.svg",
+    "daemonsPageBtn": ":/icon/toggles.svg",
+    "applyPageBtn": ":/icon/check-circle.svg",
+    "posterboardPageBtn": ":/icon/wallpaper.svg",
+    "settingsPageBtn": ":/icon/gear.svg",
+    "mainDevBtn": ":/icon/github.svg",
+    "discordBtn": ":/icon/discord.svg",
+    "starOnGithubBtn": ":/icon/star.svg",
+    "leminGithubBtn": ":/icon/github.svg",
+    "leminTwitterBtn": ":/icon/twitter.svg",
+    "leminKoFiBtn": ":/icon/currency-dollar.svg",
+}
+
+# Classic home "credits" buttons that hardcode dark borders in the .ui.
+_CLASSIC_BORDERED_BTNS = [
+    "helpFromBtn", "posterRestoreBtn", "snoolieBtn", "disfordottieBtn",
+    "mikasaBtn", "wind0ws11AeroBtn", "translatorsBtn", "libiBtn",
+    "duyBtn", "jjtechBtn", "qtBtn",
+]
+
+_CARET_SVG = ('<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" '
+              'fill="{color}" viewBox="0 0 16 16">'
+              '<path d="M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4 '
+              'h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z"/></svg>')
 
 class MainWindow(QtWidgets.QMainWindow, DeviceBarMixin, SettingsMixin,
                  NavigationMixin, ApplyMixin):
@@ -74,11 +113,15 @@ class MainWindow(QtWidgets.QMainWindow, DeviceBarMixin, SettingsMixin,
         # full-screen iOS); apply_theme() below applies it
         self.theme_manager = ThemeManager(self)
 
+        # Color theme manager (dark/light + accent)
+        self._color_theme = ColorThemeManager.instance()
+        self._color_theme.theme_changed.connect(self._on_color_theme_changed)
+
         # build the iOS-style pages stack
         # 0 = home, 1 = tweaks, 2 = posterboard, 3 = daemons, 4 = settings,
         # 5 = statusbar, 6 = apply, 7 = springboard, 8 = internal, 9 = liquidglass
         self.ios_pages = QtWidgets.QStackedWidget(self)
-        self.ios_pages.setStyleSheet("background-color: #1e1e1e;")
+        self.ios_pages.setStyleSheet(t("page_bg"))
         self.ios_home = IOSHomePage(self)
         self.ios_tweaks = IOSTweaksPage(self)
         self.ios_posterboard = IOSPosterboardPage(self)
@@ -201,3 +244,84 @@ class MainWindow(QtWidgets.QMainWindow, DeviceBarMixin, SettingsMixin,
         self.ui.posterboardPageBtn.clicked.connect(self.on_posterboardPageBtn_clicked)
         self.ui.applyPageBtn.clicked.connect(self.on_applyPageBtn_clicked)
         self.ui.settingsPageBtn.clicked.connect(self.on_settingsPageBtn_clicked)
+
+        # Apply the initial themed global stylesheet
+        self._apply_global_stylesheet()
+
+    # ---- Color theme reactivity ------------------------------------------
+
+    def _apply_global_stylesheet(self):
+        """Re-apply the global stylesheet using the current color theme."""
+        self.setStyleSheet(t("global"))
+        # Also update the QPalette so native widgets pick up the colors
+        QtWidgets.QApplication.instance().setPalette(self._color_theme.build_palette())
+        # Re-style the ios_pages stack
+        self.ios_pages.setStyleSheet(t("page_bg"))
+        # Re-style the classic chrome (sidebar icons, device bar, home toolbar)
+        self._retheme_classic()
+
+    def _retheme_classic(self):
+        """Re-color the classic shell: chrome icons, device picker, version
+        link and the hardcoded-dark credit buttons."""
+        c = self._color_theme.colors
+
+        # Recolor white SVG chrome icons to the current text color
+        for obj_name, res in _CLASSIC_THEMED_ICONS.items():
+            widget = getattr(self.ui, obj_name, None)
+            if widget is not None:
+                widget.setIcon(theme_icon(res, c.text_primary))
+
+        # Device picker combo + themed drop-down caret
+        caret_path = self._themed_caret(c.text_secondary)
+        self.ui.devicePicker.setStyleSheet(
+            themed_stylesheet("device_picker", caret=caret_path))
+
+        # Version link inherits white from the .ui — restyle to text_secondary
+        self.ui.phoneNameLbl.setStyleSheet(f"color: {c.text_primary};")
+        self.ui.phoneVersionLbl.setText(
+            f'<a style="text-decoration:none; color:{c.text_secondary}" href="#">Version</a>')
+
+        # Always-visible shell chrome: the sidebar and device bar are shown on
+        # every page/tab, so their text color must be themed explicitly
+        # (otherwise it falls back to whatever the .ui bundled).
+        chrome = f"""
+            QToolButton {{
+                color: {c.text_primary};
+                background: transparent;
+            }}
+            QToolButton:hover {{
+                color: {c.text_primary};
+                background-color: {c.surface_hover};
+            }}
+            QLabel {{ color: {c.text_primary}; }}
+        """
+        self.ui.sidebar.setStyleSheet(chrome)
+        self.ui.deviceBar.setStyleSheet(chrome)
+
+        # Credit buttons hardcode #3b3b3b borders in the generated .ui
+        bordered_style = themed_stylesheet("classic_bordered_btn")
+        for obj_name in _CLASSIC_BORDERED_BTNS:
+            widget = getattr(self.ui, obj_name, None)
+            if widget is not None:
+                widget.setStyleSheet(bordered_style)
+
+    def _themed_caret(self, color_hex: str) -> str:
+        """Write a themed drop-down caret SVG next to the cached ones and
+        return its file path for the device_picker stylesheet."""
+        import os
+        from tempfile import gettempdir
+        path = os.path.join(gettempdir(),
+                            f"gn_caret_{color_hex.strip('#').lower()}.svg")
+        if not os.path.exists(path):
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(_CARET_SVG.format(color=color_hex))
+        return path.replace(os.sep, "/")
+
+    def _on_color_theme_changed(self):
+        """Called when the color theme (dark/light or accent) changes."""
+        self._apply_global_stylesheet()
+        # Force re-render of all iOS page stylesheets by re-applying them
+        for i in range(self.ios_pages.count()):
+            page = self.ios_pages.widget(i)
+            if page and hasattr(page, '_retheme'):
+                page._retheme()

--- a/src/gui/pages/main/home.py
+++ b/src/gui/pages/main/home.py
@@ -3,6 +3,7 @@ from webbrowser import open_new_tab
 from ..page import Page
 from src.qt.mainwindow_ui import Ui_Nugget
 from src.gui.preset_widget import PresetWidget
+from src.gui.theme import ColorThemeManager
 
 class HomePage(Page):
     def __init__(self, window, ui: Ui_Nugget):
@@ -79,12 +80,16 @@ class HomePage(Page):
             self.show_uuid = True
             uuid = self.window.device_manager.get_current_device_udid()
             if uuid != "":
-                self.ui.phoneVersionLbl.setText(f"<a style=\"text-decoration:none; color: white\" href=\"#\">{uuid}</a>")
+                c = ColorThemeManager.instance().colors
+                self.ui.phoneVersionLbl.setText(
+                    f"<a style=\"text-decoration:none; color: {c.text_secondary};\" href=\"#\">{uuid}</a>")
 
     def show_version_text(self, version: str, build: str):
-        support_str: str = "<span style=\"color: #32d74b;\">" + QCoreApplication.tr("Supported!") + "</span></a>"
+        c = ColorThemeManager.instance().colors
+        support_str: str = f"<span style=\"color: {c.success};\">" + QCoreApplication.tr("Supported!") + "</span></a>"
         if not self.window.device_manager.get_current_device_is_supported_by_fork():
-            support_str = "<span style=\"color: #ff0000;\">" + QCoreApplication.tr("Not Supported.") + "</span></a>"
+            support_str = f"<span style=\"color: {c.error};\">" + QCoreApplication.tr("Not Supported.") + "</span></a>"
         elif self.window.device_manager.get_current_device_partially_supported():
-            support_str = "<span style=\"color: #ffd60a;\">" + QCoreApplication.tr("Partially Supported") + "</span></a>"
-        self.ui.phoneVersionLbl.setText(f"<a style=\"text-decoration:none; color: white;\" href=\"#\">iOS {version} ({build}) {support_str}")
+            support_str = f"<span style=\"color: {c.warning};\">" + QCoreApplication.tr("Partially Supported") + "</span></a>"
+        self.ui.phoneVersionLbl.setText(
+            f"<a style=\"text-decoration:none; color: {c.text_secondary};\" href=\"#\">iOS {version} ({build}) {support_str}")

--- a/src/gui/pages/tools/daemons.py
+++ b/src/gui/pages/tools/daemons.py
@@ -1,6 +1,7 @@
 from ..page import Page
 from src.qt.mainwindow_ui import Ui_Nugget
 from src.gui.ios.daemons import IOSDaemonsContent
+from src.gui.theme import ColorThemeManager
 
 
 class DaemonsPage(Page):
@@ -14,8 +15,9 @@ class DaemonsPage(Page):
         if self._content is not None:
             return
 
+        c = ColorThemeManager.instance().colors
         self.ui.daemonsScrollArea.setStyleSheet(
-            "background-color: #1e1e1e; border: none;")
+            f"background-color: {c.bg_primary}; border: none;")
         self._content = IOSDaemonsContent(
             self.window, self.ui.daemonsScrollContent)
         self.ui.daemonsScrollLayout.addWidget(self._content)

--- a/src/gui/preset_widget.py
+++ b/src/gui/preset_widget.py
@@ -10,6 +10,8 @@ from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QFrame,
 )
 
+from src.gui.theme import ColorThemeManager
+
 
 class PresetBanner(QFrame):
     """A card that displays the active preset and a manage shortcut."""
@@ -18,29 +20,7 @@ class PresetBanner(QFrame):
         super().__init__(parent)
         self.setObjectName("presetBanner")
         self.setFrameShape(QFrame.StyledPanel)
-
-        if ios_style:
-            self.setStyleSheet("""
-                PresetBanner {
-                    background-color: #1C1C1E;
-                    border-radius: 12px;
-                    border: none;
-                }
-            """)
-            text_color = "#FFFFFF"
-            sub_color = "#8E8E93"
-            accent = "#007AFF"
-        else:
-            self.setStyleSheet("""
-                PresetBanner {
-                    background-color: #2C2C2E;
-                    border-radius: 10px;
-                    border: none;
-                }
-            """)
-            text_color = "#FFFFFF"
-            sub_color = "#8E8E93"
-            accent = "#0A84FF"
+        self._ios_style = ios_style
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(16, 12, 16, 12)
@@ -51,29 +31,51 @@ class PresetBanner(QFrame):
 
         self.caption_lbl = QLabel(QCoreApplication.translate(
             "Nugget", "Active preset"))
-        self.caption_lbl.setStyleSheet(f"font-size: 12px; color: {sub_color};")
         text_col.addWidget(self.caption_lbl)
 
         self.active_lbl = QLabel(QCoreApplication.translate("Nugget", "AutoSave"))
-        self.active_lbl.setStyleSheet(f"font-size: 17px; font-weight: 600; color: {text_color};")
         text_col.addWidget(self.active_lbl)
 
         layout.addLayout(text_col, 1)
 
         self.manage_btn = QPushButton(QCoreApplication.translate("Nugget", "Manage"), self)
         self.manage_btn.setCursor(Qt.PointingHandCursor)
+        layout.addWidget(self.manage_btn)
+
+        self._retheme()
+        ColorThemeManager.instance().theme_changed.connect(self._retheme)
+
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        if self._ios_style:
+            self.setStyleSheet(f"""
+                PresetBanner {{
+                    background-color: {c.bg_secondary};
+                    border-radius: 12px;
+                    border: none;
+                }}
+            """)
+        else:
+            self.setStyleSheet(f"""
+                PresetBanner {{
+                    background-color: {c.surface_hover};
+                    border-radius: 10px;
+                    border: none;
+                }}
+            """)
+        self.caption_lbl.setStyleSheet(f"font-size: 12px; color: {c.text_secondary};")
+        self.active_lbl.setStyleSheet(f"font-size: 17px; font-weight: 600; color: {c.text_primary};")
         self.manage_btn.setStyleSheet(f"""
             QPushButton {{
                 background-color: transparent;
-                color: {accent};
+                color: {c.accent};
                 font-size: 15px;
                 font-weight: 600;
                 border: none;
                 padding: 8px 12px;
             }}
-            QPushButton:hover {{ color: #0066CC; }}
+            QPushButton:hover {{ color: {c.accent_hover}; }}
         """)
-        layout.addWidget(self.manage_btn)
 
     def set_active_preset(self, name: str):
         self.active_lbl.setText(name or QCoreApplication.translate("Nugget", "AutoSave"))
@@ -91,25 +93,33 @@ class PresetWidget(QWidget):
         super().__init__(parent)
         self.window = window
         self._on_manage = on_manage
+        self._ios_style = ios_style
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(8)
 
-        header = QLabel()
-        if ios_style:
-            header.setText(QCoreApplication.translate("Nugget", "PRESETS"))
-            header.setStyleSheet(
-                "font-size: 13px; font-weight: 600; color: #8E8E93;"
-                "letter-spacing: 0.5px; padding-left: 4px;")
-        else:
-            header.setText(QCoreApplication.translate("Nugget", "Presets"))
-            header.setStyleSheet("font-size: 16px; font-weight: 600; color: #FFFFFF;")
-        layout.addWidget(header)
+        self._header = QLabel()
+        layout.addWidget(self._header)
 
         self.banner = PresetBanner(ios_style=ios_style)
         self.banner.manage_btn.clicked.connect(self._on_manage_pressed)
         layout.addWidget(self.banner)
+
+        self._retheme()
+        ColorThemeManager.instance().theme_changed.connect(self._retheme)
+
+    def _retheme(self):
+        c = ColorThemeManager.instance().colors
+        if self._ios_style:
+            self._header.setText(QCoreApplication.translate("Nugget", "PRESETS"))
+            self._header.setStyleSheet(
+                f"font-size: 13px; font-weight: 600; color: {c.text_secondary};"
+                "letter-spacing: 0.5px; padding-left: 4px;")
+        else:
+            self._header.setText(QCoreApplication.translate("Nugget", "Presets"))
+            self._header.setStyleSheet(f"font-size: 16px; font-weight: 600; color: {c.text_primary};")
+        self.banner._retheme()
 
     def _on_manage_pressed(self):
         if self._on_manage is not None:

--- a/src/gui/theme/__init__.py
+++ b/src/gui/theme/__init__.py
@@ -1,0 +1,40 @@
+from PySide6.QtGui import QColor, QIcon, QImage, QPainter, QPixmap
+
+from src.gui.theme.theme_manager import ColorThemeManager
+from src.gui.theme.colors import DARK, LIGHT, ACCENT_PRESETS
+from src.gui.theme.styles import STYLES
+from src.gui.theme.accent_picker import AccentPicker
+
+
+def t(style_key: str) -> str:
+    """Render a named stylesheet template with the current theme colors."""
+    tm = ColorThemeManager.instance()
+    template = STYLES[style_key]
+    return template.format_map(tm.colors.__dict__)
+
+
+def themed_stylesheet(style_key: str, **extra) -> str:
+    """Render a stylesheet template with the current colors plus runtime
+    extras (e.g. a generated caret image path passed as ``caret=...``)."""
+    tm = ColorThemeManager.instance()
+    payload = dict(tm.colors.__dict__)
+    payload.update(extra)
+    return STYLES[style_key].format_map(payload)
+
+
+def theme_icon(resource_path: str, color_hex: str) -> QIcon:
+    """Recolor a monochrome (white) SVG icon to *color_hex* using its alpha."""
+    img = QImage(resource_path)
+    img = img.convertToFormat(QImage.Format.Format_ARGB32)
+    painter = QPainter(img)
+    painter.setCompositionMode(
+        QPainter.CompositionMode.CompositionMode_SourceIn)
+    painter.fillRect(img.rect(), QColor(color_hex))
+    painter.end()
+    return QIcon(QPixmap.fromImage(img))
+
+
+__all__ = [
+    "ColorThemeManager", "DARK", "LIGHT", "ACCENT_PRESETS", "STYLES",
+    "AccentPicker", "t", "themed_stylesheet", "theme_icon",
+]

--- a/src/gui/theme/accent_picker.py
+++ b/src/gui/theme/accent_picker.py
@@ -1,0 +1,74 @@
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QPushButton
+
+from src.gui.theme.colors import ACCENT_PRESETS
+from src.gui.theme.theme_manager import ColorThemeManager
+
+
+class AccentPicker(QWidget):
+    """Row of colored circles for choosing the accent color."""
+
+    accent_changed = Signal(str)
+
+    _SIZE = 32
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._tm = ColorThemeManager.instance()
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(10)
+        self._buttons: dict[str, QPushButton] = {}
+
+        for name in ACCENT_PRESETS:
+            btn = QPushButton(self)
+            btn.setFixedSize(self._SIZE, self._SIZE)
+            btn.setCursor(Qt.PointingHandCursor)
+            accent_hex = ACCENT_PRESETS[name][0]
+            btn.setStyleSheet(f"""
+                QPushButton {{
+                    background-color: {accent_hex};
+                    border-radius: {self._SIZE // 2}px;
+                    border: 3px solid transparent;
+                }}
+                QPushButton:hover {{
+                    border: 3px solid {accent_hex};
+                    background-color: {accent_hex};
+                }}
+            """)
+            btn.clicked.connect(lambda checked, n=name: self._on_click(n))
+            btn.setToolTip(name.capitalize())
+            self._buttons[name] = btn
+            layout.addWidget(btn)
+        layout.addStretch()
+
+        self._highlight_selected()
+
+    def _on_click(self, name: str):
+        self._tm.set_accent(name)
+        self._highlight_selected()
+        self.accent_changed.emit(name)
+
+    def _highlight_selected(self):
+        current = self._tm._accent_name
+        for name, btn in self._buttons.items():
+            accent_hex = ACCENT_PRESETS[name][0]
+            if name == current:
+                btn.setStyleSheet(f"""
+                    QPushButton {{
+                        background-color: {accent_hex};
+                        border-radius: {self._SIZE // 2}px;
+                        border: 3px solid {self._tm.c('text_primary')};
+                    }}
+                """)
+            else:
+                btn.setStyleSheet(f"""
+                    QPushButton {{
+                        background-color: {accent_hex};
+                        border-radius: {self._SIZE // 2}px;
+                        border: 3px solid transparent;
+                    }}
+                    QPushButton:hover {{
+                        border: 3px solid {accent_hex};
+                    }}
+                """)

--- a/src/gui/theme/colors.py
+++ b/src/gui/theme/colors.py
@@ -1,0 +1,133 @@
+from dataclasses import dataclass, replace
+
+
+@dataclass(frozen=True)
+class ThemeColors:
+    """All named color slots used across the application."""
+
+    # Surfaces
+    bg_primary: str
+    bg_secondary: str
+    bg_tertiary: str
+    bg_input: str
+    bg_elevated: str
+
+    # Text
+    text_primary: str
+    text_secondary: str
+    text_disabled: str
+    text_inverse: str
+
+    # Accent
+    accent: str
+    accent_hover: str
+    accent_pressed: str
+
+    # Semantic
+    success: str
+    error: str
+    warning: str
+
+    # Borders / dividers
+    border: str
+    divider: str
+
+    # Interactive
+    scrollbar: str
+    scrollbar_pressed: str
+    selection: str
+
+    # Special
+    card_border: str
+    surface_hover: str
+    danger_text: str
+
+    def with_accent(self, accent: str, hover: str, pressed: str) -> "ThemeColors":
+        return replace(self, accent=accent, accent_hover=hover, accent_pressed=pressed)
+
+
+# ---------------------------------------------------------------------------
+# Dark palette (matches the current hardcoded colors exactly)
+# ---------------------------------------------------------------------------
+DARK = ThemeColors(
+    bg_primary="#1e1e1e",
+    bg_secondary="#1C1C1E",
+    bg_tertiary="#2C2C2E",
+    bg_input="#1C1C1E",
+    bg_elevated="#1e1e1e",
+
+    text_primary="#FFFFFF",
+    text_secondary="#8E8E93",
+    text_disabled="#787878",
+    text_inverse="#FFFFFF",
+
+    accent="#007AFF",
+    accent_hover="#0066CC",
+    accent_pressed="#0055AA",
+
+    success="#30D158",
+    error="#FF453A",
+    warning="#FFD60A",
+
+    border="#3A3A3C",
+    divider="#3A3A3C",
+
+    scrollbar="#3b3b3b",
+    scrollbar_pressed="#535353",
+    selection="#007AFF",
+
+    card_border="#3A3A3C",
+    surface_hover="#2C2C2E",
+    danger_text="#FF453A",
+)
+
+
+# ---------------------------------------------------------------------------
+# Light palette (iOS Settings-style)
+# ---------------------------------------------------------------------------
+LIGHT = ThemeColors(
+    bg_primary="#F2F2F7",
+    bg_secondary="#FFFFFF",
+    bg_tertiary="#E5E5EA",
+    bg_input="#FFFFFF",
+    bg_elevated="#FFFFFF",
+
+    text_primary="#000000",
+    text_secondary="#8E8E93",
+    text_disabled="#C7C7CC",
+    text_inverse="#FFFFFF",
+
+    accent="#007AFF",
+    accent_hover="#0066CC",
+    accent_pressed="#0055AA",
+
+    success="#34C759",
+    error="#FF3B30",
+    warning="#FF9500",
+
+    border="#C6C6C8",
+    divider="#C6C6C8",
+
+    scrollbar="#C7C7CC",
+    scrollbar_pressed="#AEAEB2",
+    selection="#007AFF",
+
+    card_border="#00000000",
+    surface_hover="#E5E5EA",
+    danger_text="#FF3B30",
+)
+
+
+# ---------------------------------------------------------------------------
+# Accent presets: (normal, hover, pressed)
+# ---------------------------------------------------------------------------
+ACCENT_PRESETS = {
+    "blue":     ("#007AFF", "#0066CC", "#0055AA"),
+    "purple":   ("#AF52DE", "#9B47C4", "#893DAB"),
+    "pink":     ("#FF2D55", "#E6284D", "#CC2244"),
+    "red":      ("#FF3B30", "#E6352B", "#CC2F26"),
+    "orange":   ("#FF9500", "#E68600", "#CC7700"),
+    "yellow":   ("#FFCC00", "#E6B800", "#CCA300"),
+    "green":    ("#34C759", "#2EAF4E", "#289944"),
+    "teal":     ("#5AC8FA", "#50B4E6", "#46A0D2"),
+}

--- a/src/gui/theme/styles.py
+++ b/src/gui/theme/styles.py
@@ -1,0 +1,414 @@
+"""Component stylesheet templates with ``{slot}`` placeholders.
+
+Usage::
+
+    from src.gui.theme.styles import STYLES
+    widget.setStyleSheet(STYLES["card"].format_map(theme.colors.__dict__))
+"""
+
+
+STYLES = {
+    # ---- Components ------------------------------------------------------
+    "text_input_dialog": """
+        QDialog {{ background-color: {bg_elevated}; }}
+        QLabel {{ color: {text_primary}; font-size: 15px; }}
+        QLineEdit {{
+            background-color: {bg_input};
+            border: none;
+            border-radius: 10px;
+            color: {text_primary};
+            font-size: 15px;
+            padding: 12px 16px;
+        }}
+        QPushButton {{
+            background-color: {accent};
+            border-radius: 10px;
+            color: {text_inverse};
+            font-size: 15px;
+            font-weight: 600;
+            padding: 12px 24px;
+            border: none;
+            min-width: 80px;
+        }}
+        QPushButton:hover {{ background-color: {accent_hover}; }}
+    """,
+
+    "number_input_dialog": """
+        QDialog {{ background-color: {bg_elevated}; }}
+        QLabel {{ color: {text_primary}; font-size: 15px; }}
+        QSpinBox {{
+            background-color: {bg_input};
+            border: none;
+            border-radius: 10px;
+            color: {text_primary};
+            font-size: 15px;
+            padding: 12px 16px;
+        }}
+        QSpinBox::up-button, QSpinBox::down-button {{ width: 0; }}
+        QPushButton {{
+            background-color: {accent};
+            border-radius: 10px;
+            color: {text_inverse};
+            font-size: 15px;
+            font-weight: 600;
+            padding: 12px 24px;
+            border: none;
+            min-width: 80px;
+        }}
+        QPushButton:hover {{ background-color: {accent_hover}; }}
+    """,
+
+    "section_header": (
+        "font-size: 13px; font-weight: 600; color: {text_secondary}; "
+        "text-transform: uppercase; letter-spacing: 0.5px; padding-left: 4px;"
+    ),
+
+    "card": """
+        IOSCard {{
+            background-color: {bg_secondary};
+            border-radius: 12px;
+            border: none;
+        }}
+    """,
+
+    "nav_bar": "background-color: {bg_secondary}; border-bottom: 1px solid {divider};",
+
+    "nav_back_btn": """
+        QPushButton {{
+            background: transparent;
+            color: {accent};
+            font-size: 17px;
+            font-weight: 400;
+            border: none;
+            padding: 8px 0;
+        }}
+        QPushButton:hover {{ color: {accent_hover}; }}
+    """,
+
+    "nav_title": "font-size: 17px; font-weight: 600; color: {text_primary};",
+
+    "nav_right_btn": """
+        QPushButton {{
+            background: transparent;
+            color: {accent};
+            font-size: 15px;
+            font-weight: 600;
+            border: none;
+            padding: 8px 0;
+        }}
+        QPushButton:hover {{ color: {accent_hover}; }}
+    """,
+
+    "settings_row": """
+        QPushButton {{
+            background-color: {bg_secondary};
+            border-radius: 10px;
+            color: {text_primary};
+            font-size: 15px;
+            text-align: left;
+            padding: 14px 16px;
+            border: none;
+        }}
+        QPushButton:hover {{ background-color: {surface_hover}; }}
+    """,
+
+    "primary_button": """
+        QPushButton {{
+            background-color: {accent};
+            border-radius: 12px;
+            color: {text_inverse};
+            font-size: 17px;
+            font-weight: 600;
+            border: none;
+        }}
+        QPushButton:hover {{ background-color: {accent_hover}; }}
+        QPushButton:pressed {{ background-color: {accent_pressed}; }}
+        QPushButton:disabled {{ background-color: {border}; color: {text_disabled}; }}
+    """,
+
+    "switch_track_on": "background-color: {success}; border-radius: 15px; border: none;",
+    "switch_track_off": "background-color: {border}; border-radius: 15px; border: none;",
+    "switch_knob": "background-color: #FFFFFF; border-radius: 13px; border: none;",
+
+    "value_label": "color: {text_secondary}; font-size: 14px;",
+
+    # ---- Pages -----------------------------------------------------------
+    "page_bg": "background-color: {bg_primary};",
+    "scroll_area": "QScrollArea {{ background-color: {bg_primary}; border: none; }}",
+
+    # ---- Settings --------------------------------------------------------
+    "settings_list": """
+        QListWidget {{
+            background-color: {bg_secondary};
+            color: {text_primary};
+            border: none;
+            border-radius: 8px;
+            padding: 4px;
+        }}
+        QListWidget::item:selected {{
+            background-color: {scrollbar_pressed};
+            color: {text_inverse};
+            border-radius: 6px;
+        }}
+    """,
+
+    "mini_button": """
+        QPushButton {{
+            background-color: {bg_tertiary};
+            border-radius: 8px;
+            color: {text_primary};
+            border: none;
+            padding: 6px 12px;
+            font-size: 13px;
+        }}
+        QPushButton:hover {{ background-color: {surface_hover}; }}
+    """,
+
+    "combo_dropdown": """
+        QComboBox {{
+            background-color: {bg_secondary};
+            border: none;
+            border-radius: 8px;
+            color: {text_primary};
+            padding: 8px 12px;
+            font-size: 14px;
+        }}
+        QComboBox::drop-down {{
+            border: none;
+            width: 24px;
+        }}
+        QComboBox QAbstractItemView {{
+            background-color: {bg_secondary};
+            border: 1px solid {divider};
+            selection-background-color: {accent};
+            selection-color: {text_inverse};
+            border-radius: 8px;
+            padding: 4px;
+        }}
+    """,
+
+    # ---- PosterBoard -----------------------------------------------------
+    "tab_bar": "background-color: {bg_primary}; border-top: 1px solid {border};",
+
+    "tab_button_inactive": "color: {text_secondary}; background: transparent; border: none; font-weight: 600; font-size: 14px;",
+    "tab_button_active": "color: {accent}; background: transparent; border: none; font-weight: 600; font-size: 14px;",
+
+    "add_icon": "background-color: {bg_secondary}; border: 2px dashed {divider}; border-radius: 12px; color: {accent}; font-size: 28px; font-weight: 300;",
+
+    "tendie_preview_btn": """
+        QToolButton {{
+            background-color: {bg_secondary};
+            color: {accent};
+            border: 1px solid {divider};
+            border-radius: 8px;
+            padding: 6px 12px;
+            font-size: 13px;
+        }}
+        QToolButton:hover {{ background-color: {surface_hover}; }}
+    """,
+
+    "tendie_delete_btn": """
+        QToolButton {{
+            background-color: {bg_secondary};
+            color: {error};
+            border: 1px solid {divider};
+            border-radius: 8px;
+            padding: 6px 12px;
+            font-size: 13px;
+        }}
+        QToolButton:hover {{ background-color: {error}; color: {text_inverse}; }}
+    """,
+
+    "template_preview": "background-color: {bg_secondary}; border: 1px solid {divider}; border-radius: 12px;",
+
+    "reset_pb_button": """
+        QPushButton {{
+            background-color: {bg_tertiary};
+            border-radius: 8px;
+            color: {error};
+            border: none;
+            padding: 10px 16px;
+            font-size: 14px;
+        }}
+        QPushButton:hover {{ background-color: {surface_hover}; }}
+    """,
+
+    "download_card_icon": "background-color: {accent}; border-radius: 10px; color: white; font-size: 20px;",
+
+    "thumb_button": """
+        QPushButton {{
+            background-color: {bg_secondary};
+            color: {accent};
+            border-radius: 8px;
+            border: none;
+            padding: 8px 16px;
+            font-size: 14px;
+        }}
+        QPushButton:hover {{ background-color: {surface_hover}; }}
+    """,
+
+    # ---- Home ------------------------------------------------------------
+    "home_title": "font-size: 32px; font-weight: 700; color: {text_primary};",
+    "home_subtitle": "color: {text_secondary}; font-size: 14px;",
+
+    "home_combo": """
+        QComboBox {{
+            background-color: {bg_secondary};
+            border: none;
+            border-radius: 10px;
+            color: {text_primary};
+            padding: 10px 14px;
+            font-size: 14px;
+        }}
+        QComboBox::drop-down {{ border: none; width: 24px; }}
+        QComboBox QAbstractItemView {{
+            background-color: {bg_secondary};
+            selection-background-color: {accent};
+            selection-color: {text_inverse};
+            border: none;
+        }}
+    """,
+
+    "home_icon_button": """
+        QPushButton {{
+            background-color: {bg_secondary};
+            color: {text_primary};
+            border-radius: 10px;
+            border: none;
+            font-size: 16px;
+            padding: 10px;
+        }}
+        QPushButton:hover {{ background-color: {surface_hover}; }}
+    """,
+
+    "home_card_header": "background-color: {bg_secondary}; border-radius: 12px 12px 0 0;",
+    "home_card_title": "font-size: 17px; font-weight: 600; color: {text_primary};",
+    "home_card_subtitle": "color: {text_secondary}; font-size: 13px;",
+
+    "process_status_green": "color: {success}; font-size: 14px; font-weight: 500;",
+    "process_status_red": "color: {error}; font-size: 14px; font-weight: 500;",
+    "process_status_blue": "color: {accent}; font-size: 14px; font-weight: 500;",
+
+    # ---- Daemons ---------------------------------------------------------
+    "safety_note": "color: {danger_text}; font-size: 12px; font-style: italic;",
+
+    # ---- Wallpaper downloader ---------------------------------------------
+    "wp_card": """
+        QFrame {{
+            background-color: {bg_secondary};
+            border-radius: 12px;
+            border: none;
+        }}
+        QFrame:hover {{ background-color: {surface_hover}; }}
+    """,
+
+    "wp_name": "color: {text_primary}; font-size: 13px; font-weight: 600;",
+    "wp_author": "color: {text_secondary}; font-size: 11px;",
+    "wp_preview_bg": "background-color: {bg_tertiary};",
+    "wp_loading_bg": "background-color: {bg_tertiary};",
+    "wp_loading_text": "color: {text_disabled}; font-size: 12px;",
+
+    "dialog_progress_bar": """
+        QProgressBar {{
+            background-color: {bg_tertiary};
+            border: none;
+            border-radius: 4px;
+            height: 8px;
+        }}
+        QProgressBar::chunk {{
+            background-color: {accent};
+            border-radius: 4px;
+        }}
+    """,
+
+    # ---- About dialog ----------------------------------------------------
+    "about_separator": "background-color: {divider};",
+    "about_desc": "color: {text_secondary}; font-size: 14px;",
+    "about_credit_title": "color: {text_secondary}; font-size: 13px; font-weight: 600;",
+    "about_link": "color: {accent}; font-size: 14px; border: none; background: transparent;",
+    "about_link_hover": "color: {accent_hover}; font-size: 14px; border: none; background: transparent;",
+
+    # ---- Interface picker ------------------------------------------------
+    "picker_frame": """
+        QFrame {{
+            background-color: {bg_secondary};
+            border-radius: 12px;
+            border: 2px solid transparent;
+        }}
+        QFrame:hover {{ border-color: {accent}; }}
+    """,
+
+    # ---- Classic chrome (device bar) -------------------------------------
+    "device_picker": """
+        #devicePicker {{
+            background-color: {bg_input};
+            border: none;
+            color: {text_primary};
+            font-size: 14px;
+            min-height: 38px;
+            min-width: 35px;
+            padding-left: 8px;
+        }}
+        #devicePicker::drop-down {{
+            image: url({caret});
+            icon-size: 16px;
+            subcontrol-position: right center;
+            margin-right: 8px;
+        }}
+        #devicePicker QAbstractItemView {{
+            background-color: {bg_tertiary};
+            outline: none;
+            margin-top: 1px;
+        }}
+        #devicePicker QAbstractItemView::item {{
+            background-color: {bg_tertiary};
+            color: {text_primary};
+            min-height: 38px;
+            padding-left: 8px;
+        }}
+        #devicePicker QAbstractItemView::item:hover {{
+            background-color: {surface_hover};
+            color: {text_primary};
+        }}
+    """,
+
+    "classic_bordered_btn": """
+        QToolButton {{
+            background: none;
+            border: 1px solid {divider};
+            color: {text_primary};
+        }}
+        QToolButton:hover {{
+            background-color: {surface_hover};
+        }}
+        QToolButton:pressed {{
+            background-color: {surface_hover};
+            color: {text_primary};
+        }}
+    """,
+
+    # ---- Global (main window stylesheet) ---------------------------------
+    "global": """
+        QWidget {{ color: {text_primary}; background-color: transparent; spacing: 0px; }}
+        QWidget:focus {{ outline: none; }}
+        QWidget[cls=central] {{ background-color: {bg_primary}; border-radius: 0px; border: 1px solid {divider}; }}
+        QLabel {{ font-size: 14px; }}
+        QToolButton {{ background-color: {bg_tertiary}; border: none; color: {text_primary}; font-size: 14px; border-radius: 8px; }}
+        QToolButton[cls=sidebarBtn] {{ background-color: transparent; icon-size: 24px; }}
+        QToolButton:pressed {{ background-color: {surface_hover}; color: {text_primary}; }}
+        QToolButton:checked {{ background-color: {accent}; color: {text_inverse}; }}
+        QCheckBox {{ spacing: 8px; font-size: 14px; }}
+        QRadioButton {{ spacing: 8px; font-size: 14px; }}
+        QLineEdit {{ border: none; background-color: transparent; color: {text_primary}; font-size: 14px; }}
+        QScrollBar:vertical {{ background: transparent; width: 8px; }}
+        QScrollBar:horizontal {{ background: transparent; height: 8px; }}
+        QScrollBar::handle {{ background: {scrollbar}; border-radius: 4px; }}
+        QScrollBar::handle:pressed {{ background: {scrollbar_pressed}; }}
+        QScrollBar::add-line, QScrollBar::sub-line {{ background: none; }}
+        QScrollBar::add-page, QScrollBar::sub-page {{ background: none; }}
+        QSlider::groove:horizontal {{ background-color: {scrollbar}; height: 4px; border-radius: 2px; }}
+        QSlider::handle:horizontal {{ background-color: {scrollbar_pressed}; width: 8px; border-radius: 4px; }}
+        QSlider::handle:horizontal:pressed {{ background-color: {accent}; }}
+        QSlider::tick:horizontal {{ background-color: {scrollbar_pressed}; width: 1px; }}
+    """,
+}

--- a/src/gui/theme/theme_manager.py
+++ b/src/gui/theme/theme_manager.py
@@ -1,0 +1,122 @@
+from PySide6.QtCore import QObject, Signal, QSettings
+from PySide6.QtGui import QColor, QPalette
+
+from src.gui.theme.colors import ThemeColors, DARK, LIGHT, ACCENT_PRESETS
+
+
+class ColorThemeManager(QObject):
+    """Manages the app's color theme (dark/light + accent).
+
+    Singleton accessed via ``ColorThemeManager.instance()``.
+    Emits ``theme_changed`` whenever the palette or accent changes so
+    connected widgets can re-render their stylesheets.
+    """
+
+    theme_changed = Signal()
+
+    _inst = None
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._settings = QSettings("GoldenNugget", "GoldenNugget")
+        self._has_explicit_mode = self._settings.contains("color_mode")
+        self._mode = self._settings.value("color_mode", "dark")
+        self._accent_name = self._settings.value("accent_color", "blue")
+        self._colors = self._build_colors()
+
+    @classmethod
+    def instance(cls) -> "ColorThemeManager":
+        if cls._inst is None:
+            cls._inst = cls()
+        return cls._inst
+
+    # ---- current palette ------------------------------------------------
+
+    @property
+    def colors(self) -> ThemeColors:
+        return self._colors
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    @property
+    def is_dark(self) -> bool:
+        return self._mode == "dark"
+
+    def c(self, slot: str) -> str:
+        """Shortcut: return the hex value for *slot* from the active palette."""
+        return getattr(self._colors, slot)
+
+    # ---- switching -------------------------------------------------------
+
+    def set_mode(self, mode: str):
+        if mode not in ("dark", "light"):
+            return
+        if mode == self._mode:
+            return
+        self._mode = mode
+        self._has_explicit_mode = True
+        self._settings.setValue("color_mode", mode)
+        self._colors = self._build_colors()
+        self.theme_changed.emit()
+
+    def set_accent(self, name: str):
+        if name not in ACCENT_PRESETS:
+            return
+        if name == self._accent_name:
+            return
+        self._accent_name = name
+        self._settings.setValue("accent_color", name)
+        self._colors = self._build_colors()
+        self.theme_changed.emit()
+
+    def set_system_theme(self, dark: bool):
+        """Sync with the OS dark/light mode (called by platform detection)."""
+        self.set_mode("dark" if dark else "light")
+
+    def apply_system_theme(self, dark: bool):
+        """Follow the OS dark/light mode, but never override a mode the user
+        chose manually via the Settings switch (that choice persists first)."""
+        if not self._has_explicit_mode:
+            self.set_mode("dark" if dark else "light")
+
+    # ---- QPalette for Fusion style ---------------------------------------
+
+    def build_palette(self) -> QPalette:
+        pal = QPalette()
+        c = self._colors
+        pal.setColor(QPalette.ColorRole.Window, QColor(c.bg_primary))
+        pal.setColor(QPalette.ColorRole.WindowText, QColor(c.text_primary))
+        pal.setColor(QPalette.ColorRole.Base, QColor(c.bg_input))
+        pal.setColor(QPalette.ColorRole.AlternateBase, QColor(c.bg_tertiary))
+        pal.setColor(QPalette.ColorRole.ToolTipBase, QColor(c.bg_elevated))
+        pal.setColor(QPalette.ColorRole.ToolTipText, QColor(c.text_primary))
+        pal.setColor(QPalette.ColorRole.Text, QColor(c.text_primary))
+        pal.setColor(QPalette.ColorRole.Button, QColor(c.bg_secondary))
+        pal.setColor(QPalette.ColorRole.ButtonText, QColor(c.text_primary))
+        pal.setColor(QPalette.ColorRole.BrightText, QColor(c.error))
+        pal.setColor(QPalette.ColorRole.Link, QColor(c.accent))
+        pal.setColor(QPalette.ColorRole.Highlight, QColor(c.accent))
+        pal.setColor(QPalette.ColorRole.HighlightedText, QColor(c.text_inverse))
+        pal.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text, QColor(c.text_disabled))
+        pal.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.ButtonText, QColor(c.text_disabled))
+        pal.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.WindowText, QColor(c.text_disabled))
+        return pal
+
+    # ---- helpers ---------------------------------------------------------
+
+    def _build_colors(self) -> ThemeColors:
+        base = DARK if self._mode == "dark" else LIGHT
+        accent, hover, pressed = ACCENT_PRESETS[self._accent_name]
+        return base.with_accent(accent, hover, pressed)
+
+    def accent_hex(self) -> str:
+        """Return the ``(r, g, b)`` tuple for the current accent."""
+        accent, _, _ = ACCENT_PRESETS[self._accent_name]
+        return accent
+
+    def accent_rgb(self) -> tuple:
+        accent, _, _ = ACCENT_PRESETS[self._accent_name]
+        q = QColor(accent)
+        return (q.red(), q.green(), q.blue())


### PR DESCRIPTION
## What
Adds a full dark/light **color theme system** with accent color customization to the GUI.

## Highlights
- New `src/gui/theme/` package:
  - `colors.py` — frozen `ThemeColors` dataclass with `DARK` / `LIGHT` palettes and 8 `ACCENT_PRESETS`.
  - `theme_manager.py` — `ColorThemeManager` singleton (persisted via QSettings `color_mode` / `accent_color`, emits `theme_changed`).
  - `styles.py` — named stylesheet templates rendered through `t(key)` / `themed_stylesheet(...)`.
  - `accent_picker.py` — accent color picker (self-rethemes on `theme_changed`).
  - `theme_icon()` — recolors monochrome white SVG icons to the current text color.
- Settings → **Appearance**: "Dark Mode" switch + "Accent Color" picker.
- **System theme detection**: `QStyleHints.colorSchemeChanged` drives `apply_system_theme()` from `main_app.py`; the app follows the OS until the user toggles the switch, then the saved choice wins.
- Refactored ~150 hardcoded colors across iOS pages, dialogs, interface picker, preset widget, and classic pages to use the theme.
- Classic shell (sidebar + device bar) now explicitly restyles its icons and text on every theme change.

## Docs
- `AGENTS.md` documents the theme system (palette slots, styling contract: `t()` is the only theme accessor, `_retheme()` / `_auto_retheme()` conventions, system-theme detection wiring).